### PR TITLE
[App] 회원가입 | 로그인 → 회원가입을 연결하고 내부 버튼 상태 로직을 개선했어요

### DIFF
--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
@@ -11,7 +11,7 @@ import RxSwift
 import AuthenticationServices
 
 public protocol SignInRouting: ViewableRouting {
-    func routeToSignUp()
+    func routeToSignUp(payload: SignUpPayload)
 }
 
 protocol SignInPresentable: Presentable {
@@ -57,6 +57,10 @@ final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInIn
                         print("🦊 signIn")
                         self?.listener?.signInDidTapClose()
                     case .signUp(let info):
+                        self?.router?.routeToSignUp(
+                            payload: .init(id: info.id,
+                                           token: info.token,
+                                           email: info.email))
                 }
             })
             .disposeOnDeactivate(interactor: self)

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
@@ -56,10 +56,7 @@ final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInIn
                         // FIXME: 임시로 적용한 로직입니다. 추후 제거
                         print("🦊 signIn")
                         self?.listener?.signInDidTapClose()
-                    case .signUp:
-                        // FIXME: 임시로 적용한 로직입니다. 추후 제거
-                        print("🦊 signUp")
-                        self?.listener?.signInDidTapClose()
+                    case .signUp(let info):
                 }
             })
             .disposeOnDeactivate(interactor: self)

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
@@ -28,10 +28,10 @@ final class SignInRouter: ViewableRouter<SignInInteractable, SignInViewControlla
         interactor.router = self
     }
 
-    func routeToSignUp() {
+    func routeToSignUp(payload: SignUpPayload) {
         if childRouting != nil { return }
 
-        let router = signUpBuilder.build(withListener: self.interactor)
+        let router = signUpBuilder.build(withListener: self.interactor, payload: payload)
         let viewController = router.viewControllable
         viewController.uiviewController.modalPresentationStyle = .fullScreen
         viewControllable.present(viewController, animated: false)

--- a/SixthSense/Account/Sources/SignUp/Domain/Entities/SignUpPayload.swift
+++ b/SixthSense/Account/Sources/SignUp/Domain/Entities/SignUpPayload.swift
@@ -1,0 +1,15 @@
+//
+//  SignUpPayload.swift
+//  Account
+//
+//  Created by 문효재 on 2022/07/25.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+
+public struct SignUpPayload {
+   public var id: String
+   public var token: String
+   public var email: String?
+}

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpBuilder.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpBuilder.swift
@@ -15,7 +15,7 @@ final class SignUpComponent: Component<SignUpDependency> { }
 // MARK: - Builder
 
 public protocol SignUpBuildable: Buildable {
-    func build(withListener listener: SignUpListener) -> SignUpRouting
+    func build(withListener listener: SignUpListener, payload: SignUpPayload) -> SignUpRouting
 }
 
 public final class SignUpBuilder: Builder<SignUpDependency>, SignUpBuildable {
@@ -24,10 +24,10 @@ public final class SignUpBuilder: Builder<SignUpDependency>, SignUpBuildable {
         super.init(dependency: dependency)
     }
 
-    public func build(withListener listener: SignUpListener) -> SignUpRouting {
+    public func build(withListener listener: SignUpListener, payload: SignUpPayload) -> SignUpRouting {
         let component = SignUpComponent(dependency: dependency)
         let viewController = SignUpViewController()
-        let interactor = SignUpInteractor(presenter: viewController)
+        let interactor = SignUpInteractor(presenter: viewController, payload: payload)
         interactor.listener = listener
         return SignUpRouter(interactor: interactor, viewController: viewController)
     }

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -46,8 +46,10 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
     private let veganStageInputValidRelay: PublishRelay<Int> = .init()
 
     private var signUpRequestModel: SignUpRequestModel?
+    private let payload: SignUpPayload
 
-    override init(presenter: SignUpPresentable) {
+    init(presenter: SignUpPresentable, payload: SignUpPayload) {
+        self.payload = payload
         super.init(presenter: presenter)
         presenter.listener = self
         presenter.handler = self

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -57,9 +57,7 @@ final class SignUpViewController: UIViewController, SignUpPresentable, SignUpVie
         label.textColor = .main
     }
 
-    private lazy var bottomButton = AppButton(title: "다음").then { button in
-        button.hasFocused = false
-    }
+    private lazy var bottomButton = AppButton(title: "다음")
 
     // MARK: - Vars
     private let progressPositions: [Float] = [0.25, 0.5, 0.75, 1]
@@ -165,7 +163,6 @@ private extension SignUpViewController {
 
         bottomButton.rx.tap
             .bind(onNext: { [weak self] in
-            self?.bottomButton.hasFocused = false
             guard self?.signUpPageView.goToNextPage() == true else {
                 // 확인 버튼
                 // TODO: - request API
@@ -186,18 +183,14 @@ private extension SignUpViewController {
         guard let handler = handler else { return }
 
         handler.visibleNicknameValid
-            .bind(with: bottomButton,
-                  onNext: { [weak self] button, isValid in
-                      button.hasFocused = isValid
+            .bind(onNext: { [weak self] isValid in
                       self?.signUpPageView.nickNameInputView.nicknameTextField.isValidText = isValid
                   })
             .disposed(by: disposeBag)
 
 
         handler.genderInputValid
-            .bind(with: bottomButton,
-                  onNext: { button, tag in
-                      button.hasFocused = tag == -1 ? false : true
+            .bind(onNext: { tag in
                       let vc = self.signUpPageView.genderInputView
                       vc.selectButtons.forEach {
                           if $0.tag == tag {
@@ -209,18 +202,9 @@ private extension SignUpViewController {
                   })
             .disposed(by: disposeBag)
 
-        handler.visibleBirthInputValid
-            .bind(with: bottomButton,
-                  onNext: { button, isValid in
-                      button.hasFocused = isValid
-                  })
-            .disposed(by: disposeBag)
-
         handler.veganStageInputValid
-            .bind(with: bottomButton,
-                  onNext: { [weak self] button, tag in
+            .bind(onNext: { [weak self] tag in
                       guard let self = self else { return }
-                      button.hasFocused = tag == -1 ? false : true
                       let vc = self.signUpPageView.veganInputView
                       vc.imageButtons.forEach {
                           if $0.tag == tag {
@@ -235,6 +219,10 @@ private extension SignUpViewController {
         handler.textDoneButton
             .map(\.rawValue)
             .bind(to: bottomButton.rx.titleText)
+            .disposed(by: self.disposeBag)
+        
+        handler.enableButton
+            .bind(to: bottomButton.rx.hasFocused)
             .disposed(by: self.disposeBag)
     }
 

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -231,6 +231,11 @@ private extension SignUpViewController {
                       }
                   })
             .disposed(by: disposeBag)
+        
+        handler.textDoneButton
+            .map(\.rawValue)
+            .bind(to: bottomButton.rx.titleText)
+            .disposed(by: self.disposeBag)
     }
 
     /// rxKeyboard를 사용해서 keyboard height 만큼 view의 constratint을 업데이트 한다.
@@ -269,7 +274,6 @@ private extension SignUpViewController {
 
     /// SignUpPageViewController의 화면 전환에 관련된 UI 수행을 한다.
     private func stepChanged(_ step: SignUpSteps) {
-        bottomButton.titleText = step.buttonTitle
         navigationTitle.text = step.navigationTitle
         stepIconImageView.image = step.stepIcon
         updateProgressBar(when: step)
@@ -313,6 +317,25 @@ private extension SignUpViewController {
 }
 
 extension SignUpViewController: SignUpPresenterAction {
+    var nicknameViewDidAppear: Observable<Void> {
+        signUpPageView.nickNameInputView.rx.viewDidAppear.map { _ in () }.asObservable()
+    }
+    
+    var genderViewDidAppear: Observable<Void> {
+        signUpPageView.genderInputView.rx.viewDidAppear.map { _ in () }.asObservable()
+    }
+    
+    var birthDateViewDidAppear: Observable<Void> {
+        signUpPageView.birthInputView.rx.viewDidAppear.map { _ in () }.asObservable()
+    }
+    
+    var veganStageViewDidAppear: Observable<Void> {
+        signUpPageView.veganInputView.rx.viewDidAppear.map { _ in () }.asObservable()
+    }
+    
+    var doneButtonDidTap: Observable<Void> {
+        bottomButton.rx.tap.map { _ in () }.asObservable()
+    }
 
     var nicknameDidInput: Observable<String> {
         signUpPageView.nickNameInputView.nicknameTextField.rx.text.orEmpty.distinctUntilChanged().asObservable()


### PR DESCRIPTION
### 작업사항
로그인 → 회원가입을 SignUpPaylaod를 사용하여 데이터를 이동시키고
내부 버튼 상태 처리를 기존 View에서 Interactor로 이동시켰어요
그리고 SignUpRequests 프로퍼티를 합치는 로직 작성하였어요

<img width="446" alt="image" src="https://user-images.githubusercontent.com/69489688/180811322-84290349-cd67-4f28-b520-76fc9614edc9.png">

### 스크린샷

https://user-images.githubusercontent.com/69489688/180810665-e9a23914-04a3-41c1-9d20-24c60c5f287e.MP4


