### PR TITLE
[APP] `SignUpRIB`에 에러 메세지를 추가했어요

### DIFF
--- a/SixthSense/Account/Sources/SignUp/Domain/UseCases/SignUpUseCase.swift
+++ b/SixthSense/Account/Sources/SignUp/Domain/UseCases/SignUpUseCase.swift
@@ -30,7 +30,6 @@ final class SignUpUseCaseImpl: SignUpUseCase {
     }
 
     func fetchSignUp(reqeust: SignUpRequest) -> Observable<String> {
-        return userRepository.signUp(request: reqeust).debug().asObservable()
+        return userRepository.signUp(request: reqeust).asObservable()
     }
-
 }

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -157,20 +157,18 @@ private extension SignUpInteractor {
             .disposeOnDeactivate(interactor: self)
 
         action.doneButtonDidTap
-            .filter({ [weak self] in
+            .do(onNext: { [weak self] in
             if $0 == .nickname {
                 self?.isUseableNickname(self?.requests.nickname ?? "")
                 self?.buttonDidTapRelay.accept(false)
-                return false
             }
 
             if $0 == .veganStage {
                 self?.doSignUp()
                 self?.buttonDidTapRelay.accept(false)
-                return false
             }
-            return true
         })
+            .filter { ![.nickname, .veganStage].contains($0) }
             .subscribe(onNext: { [weak self] step in
             self?.buttonDidTapRelay.accept(true)
         })
@@ -180,23 +178,21 @@ private extension SignUpInteractor {
     private func bindNickname(action: SignUpPresenterAction) {
 
         action.nicknameDidInput
-            .filter({ [weak self] in
+            .do(onNext: { [weak self] in
+
             guard !$0.isEmpty else {
                 self?.fetchEnableButton(false)
                 self?.visibleNicknameValidRelay.accept(true) // 에러메세지 지우기
-                return false
+                return
             }
-            return true
-        })
-            .filter({ [weak self] in
+
             guard self?.isValidNickname($0) == true else {
                 self?.fetchEnableButton(false)
                 self?.visibleNicknameValidRelay.accept(false)
-                return false
+                return
             }
-            return true
-
         })
+            .filter { [weak self] in !$0.isEmpty && (self?.isValidNickname($0) == true) }
             .subscribe(onNext: { [weak self] in
             guard let self = self else { return }
 

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -59,9 +59,9 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
     weak var router: SignUpRouting?
     weak var listener: SignUpListener?
 
-    private let visibleNicknameValidRelay: BehaviorRelay<Bool> = .init(value: false)
+    private let visibleNicknameValidRelay: BehaviorRelay<Bool> = .init(value: true)
     private let genderInputValidRelay: PublishRelay<Int> = .init()
-    private let visibleBirthInputValidRelay: BehaviorRelay<Bool> = .init(value: false)
+    private let visibleBirthInputValidRelay: BehaviorRelay<Bool> = .init(value: true)
     private let veganStageInputValidRelay: PublishRelay<Int> = .init()
 
     private let enableButtonRelay: PublishRelay<Bool> = .init()
@@ -69,7 +69,7 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
     private let buttonDidTapRelay: PublishRelay<Bool> = .init()
     private let nicknameButtonRelay: PublishRelay<Bool> = .init()
 
-    private let nicknameCheckValidRelay: BehaviorRelay<Bool> = .init(value: false)
+    private let nicknameCheckValidRelay: PublishRelay<Bool> = .init()
 
     private var requests: SignUpRequest = .init()
     private let payload: SignUpPayload
@@ -102,58 +102,11 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
         super.willResignActive()
     }
 
-    func bindSubViewActions() {
-        guard let action = presenter.action else { return }
-        bindBottomButton(action: action)
-        bindNickname(action: action)
-
-        action.genderDidInput
-            .subscribe(onNext: { [weak self] in
-            guard let self = self else { return }
-            self.requests.gender = $0.stringValue
-            self.fetchEnableButton(true)
-            self.genderInputValidRelay.accept($0.rawValue)
-        })
-            .disposeOnDeactivate(interactor: self)
-
-        action.birthDidInput
-            .subscribe(onNext: { [weak self] in
-            guard let self = self else { return }
-            let birthText = $0.joined()
-            guard birthText.count == 8 else {
-                self.visibleBirthInputValidRelay.accept(false)
-                self.fetchEnableButton(false)
-                return
-            }
-            self.requests.birthDay = birthText
-            self.visibleBirthInputValidRelay.accept(true)
-            self.fetchEnableButton(true)
-        })
-            .disposeOnDeactivate(interactor: self)
-
-        action.veganStageDidInput
-            .subscribe(onNext: { [weak self] in
-            guard let self = self else { return }
-            self.veganStageInputValidRelay.accept($0.rawValue)
-            self.requests.vegannerStage = $0.stringValue
-            self.fetchEnableButton(true)
-        })
-            .disposeOnDeactivate(interactor: self)
-    }
-
-    private func fetchDoneButtonText(buttonType: SignUpButtonType) {
-        self.textDoneButtonRelay.accept(buttonType)
-    }
-
-    private func fetchEnableButton(_ enable: Bool) {
-        self.enableButtonRelay.accept(enable)
-    }
-
-    private func isValidNickname(_ nickname: String) -> Bool {
-        let nicknameRegex = "^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9]+$"
-        let nicknameTest = NSPredicate(format: "SELF MATCHES %@",
-                                       nicknameRegex)
-        return nicknameTest.evaluate(with: nickname)
+    private func doSignUp() {
+        dependency.useCase.fetchSignUp(reqeust: self.requests)
+            .subscribe(onNext: { [weak self] _ in
+            // TODO: - 공통 데이터 모델로 변환 후 success/failure 처리
+        }).disposeOnDeactivate(interactor: self)
     }
 
     private func isUseableNickname(_ nickname: String) {
@@ -164,14 +117,25 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
         }).disposeOnDeactivate(interactor: self)
     }
 
-    private func signUp() {
-        dependency.useCase.fetchSignUp(reqeust: self.requests)
-            .subscribe(onNext: { [weak self] _ in
-            // TODO: - 공통 데이터 모델로 변환 후 success/failure 처리
-        }).disposeOnDeactivate(interactor: self)
+    func bindSubViewActions() {
+        guard let action = presenter.action else { return }
+        bindBottomButton(action: action)
+        bindNickname(action: action)
+        bindGender(action: action)
+        bindBirth(action: action)
+        bindVeganStage(action: action)
     }
 }
-extension SignUpInteractor {
+
+private extension SignUpInteractor {
+
+    private func fetchDoneButtonText(buttonType: SignUpButtonType) {
+        self.textDoneButtonRelay.accept(buttonType)
+    }
+
+    private func fetchEnableButton(_ enable: Bool) {
+        self.enableButtonRelay.accept(enable)
+    }
 
     private func bindBottomButton(action: SignUpPresenterAction) {
 
@@ -193,45 +157,116 @@ extension SignUpInteractor {
             .disposeOnDeactivate(interactor: self)
 
         action.doneButtonDidTap
-            .subscribe(onNext: { [weak self] step in
-            if step == .nickname {
+            .filter({ [weak self] in
+            if $0 == .nickname {
                 self?.isUseableNickname(self?.requests.nickname ?? "")
                 self?.buttonDidTapRelay.accept(false)
-                return
+                return false
             }
 
-            if step == .veganStage {
-                self?.signUp()
+            if $0 == .veganStage {
+                self?.doSignUp()
                 self?.buttonDidTapRelay.accept(false)
-                return
+                return false
             }
-
+            return true
+        })
+            .subscribe(onNext: { [weak self] step in
             self?.buttonDidTapRelay.accept(true)
         })
             .disposeOnDeactivate(interactor: self)
     }
 
-
     private func bindNickname(action: SignUpPresenterAction) {
 
         action.nicknameDidInput
+            .filter({ [weak self] in
+            guard !$0.isEmpty else {
+                self?.fetchEnableButton(false)
+                self?.visibleNicknameValidRelay.accept(true) // 에러메세지 지우기
+                return false
+            }
+            return true
+        })
+            .filter({ [weak self] in
+            guard self?.isValidNickname($0) == true else {
+                self?.fetchEnableButton(false)
+                self?.visibleNicknameValidRelay.accept(false)
+                return false
+            }
+            return true
+
+        })
             .subscribe(onNext: { [weak self] in
             guard let self = self else { return }
-            guard !$0.isEmpty else {
-                self.fetchEnableButton(false)
-                self.visibleNicknameValidRelay.accept(false)
-                return
-            }
 
-            let isValid = self.isValidNickname($0)
-            self.visibleNicknameValidRelay.accept(isValid)
+            self.visibleNicknameValidRelay.accept(true)
             self.requests.nickname = $0
             self.fetchEnableButton(true)
         })
             .disposeOnDeactivate(interactor: self)
     }
-}
 
+    private func bindBirth(action: SignUpPresenterAction) {
+
+        action.birthDidInput
+            .subscribe(onNext: { [weak self] in
+            guard let self = self else { return }
+            let birthText = $0.joined()
+            guard !birthText.isEmpty else {
+                self.fetchEnableButton(false)
+                self.visibleBirthInputValidRelay.accept(true) // 에러메세지 지우기
+                return
+            }
+
+            guard birthText.count == 8 && self.isValidBirth(birthText) else {
+                self.visibleBirthInputValidRelay.accept(false)
+                self.fetchEnableButton(false)
+                return
+            }
+            self.visibleBirthInputValidRelay.accept(true)
+            self.requests.birthDay = birthText
+            self.fetchEnableButton(true)
+        })
+            .disposeOnDeactivate(interactor: self)
+    }
+
+    private func bindGender(action: SignUpPresenterAction) {
+
+        action.genderDidInput
+            .subscribe(onNext: { [weak self] in
+            guard let self = self else { return }
+            self.requests.gender = $0.stringValue
+            self.fetchEnableButton(true)
+            self.genderInputValidRelay.accept($0.rawValue)
+        })
+            .disposeOnDeactivate(interactor: self)
+    }
+
+    private func bindVeganStage(action: SignUpPresenterAction) {
+        action.veganStageDidInput
+            .subscribe(onNext: { [weak self] in
+            guard let self = self else { return }
+            self.veganStageInputValidRelay.accept($0.rawValue)
+            self.requests.vegannerStage = $0.stringValue
+            self.fetchEnableButton(true)
+        })
+            .disposeOnDeactivate(interactor: self)
+    }
+
+    private func isValidNickname(_ nickname: String) -> Bool {
+        let nicknameRegex = "^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9]+$"
+        let nicknameTest = NSPredicate(format: "SELF MATCHES %@",
+                                       nicknameRegex)
+        return nicknameTest.evaluate(with: nickname)
+    }
+
+    private func isValidBirth(_ birth: String) -> Bool {
+        let birthRegex = "^(19[0-9][0-9]|20\\d{2})(0[0-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])$"
+        let birthTest = NSPredicate(format: "SELF MATCHES %@", birthRegex)
+        return birthTest.evaluate(with: birth)
+    }
+}
 
 extension SignUpInteractor: SignUpPresenterHandler {
 

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -187,7 +187,7 @@ private extension SignUpViewController {
         })
             .disposed(by: disposeBag)
 
-        handler.nicknameCheckValid.debug("닉네임")
+        handler.nicknameCheckValid
             .filter({ [weak self] in
             if !$0 {
                 self?.signUpPageView.nickNameInputView.nicknameTextField.errorString = "앗 이미 사용 중인 비거너의 이름이야ㅠㅠ"

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -359,9 +359,8 @@ extension SignUpViewController: SignUpPresenterAction {
     }
 
     var doneButtonDidTap: Observable<SignUpSteps> {
-        bottomButton.rx
-            .tap
-            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
+        bottomButton.rx.tap
+            .throttle(.seconds(2), latest: false, scheduler: MainScheduler.instance)
             .map({ self.currentStep })
             .asObservable()
     }

--- a/SixthSense/Account/Sources/SignUp/Presentation/SubViews/BirthStepViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SubViews/BirthStepViewController.swift
@@ -30,6 +30,7 @@ final class BirthStepViewController: UIViewController {
         textfield.placeholderString = "1990"
         textfield.maxLength = 4
         textfield.keyboardType = .decimalPad
+        textfield.errorString = "날짜가 맞는지 다시 확인해줄래?"
     }
 
     private var yearLabel = AppLabel().then { label in
@@ -57,10 +58,19 @@ final class BirthStepViewController: UIViewController {
     }
 
     // MARK: - Vars
-
+    let birthTextFields: [AppTextField]
     private let disposeBag = DisposeBag()
 
     // MARK: - LifeCycle
+
+    init() {
+        birthTextFields = [yearTextField, monthTextField, dayTextField]
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SixthSense/Account/Sources/SignUp/Presentation/SubViews/NicknameStepViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SubViews/NicknameStepViewController.swift
@@ -26,8 +26,7 @@ final class NicknameStepViewController: UIViewController {
 
     var nicknameTextField = AppTextField().then { textfield in
         textfield.placeholderString = "2~10자 사이로 입력해 주세요"
-        // TODO: - 기획: validation 문구 수정
-        textfield.errorString = "필수항목을 선택해 주세요.(벨리데이션 문구 필요)"
+        textfield.errorString = "국문 또는 영문만 가능해!"
         textfield.maxLength = 10
     }
 

--- a/SixthSense/Account/Sources/SignUp/Presentation/SubViews/SignUpPageViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SubViews/SignUpPageViewController.swift
@@ -10,6 +10,11 @@ import RxCocoa
 import RxSwift
 import UIKit
 
+enum SignUpPageTransition {
+    case forward
+    case backward
+}
+
 class SignUpPageViewController: UIPageViewController {
 
     // MARK: - UI
@@ -59,20 +64,28 @@ class SignUpPageViewController: UIPageViewController {
                            animated: false,
                            completion: nil)
     }
+
+    func pageTransition(type: SignUpPageTransition) {
+        switch type {
+        case .forward:
+            goToNextPage()
+        case .backward:
+            goToPreviousPage()
+        }
+    }
 }
 
-extension SignUpPageViewController {
+private extension SignUpPageViewController {
 
-    func goToNextPage() {
-        if let currentViewController = viewControllers?[0] {
-            if let nextPage = dataSource?.pageViewController(self, viewControllerAfter: currentViewController) {
-                sendRelay(where: nextPage)
-                setViewControllers([nextPage], direction: .forward, animated: true, completion: nil)
-            }
+    private func goToNextPage() {
+        if let currentViewController = viewControllers?[0],
+            let nextPage = dataSource?.pageViewController(self, viewControllerAfter: currentViewController) {
+            sendRelay(where: nextPage)
+            setViewControllers([nextPage], direction: .forward, animated: true, completion: nil)
         }
     }
 
-    func goToPreviousPage() {
+    private func goToPreviousPage() {
         if let currentViewController = viewControllers?[0] {
 
             guard currentViewController is NicknameStepViewController == false else {

--- a/SixthSense/DesignSystem/Sources/AppTextField.swift
+++ b/SixthSense/DesignSystem/Sources/AppTextField.swift
@@ -103,7 +103,6 @@ private extension AppTextField {
             errorIcon.heightAnchor.constraint(equalToConstant: 16),
             errorLabel.topAnchor.constraint(equalTo: bottomAnchor),
             errorLabel.leadingAnchor.constraint(equalTo: errorIcon.trailingAnchor, constant: 4),
-            errorLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
 


### PR DESCRIPTION
- Resolved #59 
---

### 설명
- nickname 중복 에러 메세지를 추가했어요.
- nickname validation 에러 메세지를 추가했어요.
- birth 에러 메세지를 추가했어요.

### 작업사항
- nickname 에러 메세지 추가
- birth 에러 메세지 추가
- birth validation 추가 
    ``` swift
    /// count가 8인 String에서 년,월,일 체크
    let birthRegex = "^(19[0-9][0-9]|20\\d{2})(0[0-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])$" 
    ```
- 기능단위 메서드 분리
- `AppTextField` constraint 수정
- `SignUpPageViewController` 에 `SignUpTransition` `Enum` 추가
- handler, action : `.filter`로 `subscribe` 되기 전에 예외 로직 처리
- `UITextField`에 input이 빈 스트링일 경우 에러 메세지가 보이는 버그 수정

### 스크린샷
> 닉네임 빈 스트링 입력, 에러 메세지 출력 화면

<img width="230" src="https://user-images.githubusercontent.com/62925639/182159548-6a57096e-16dd-43a5-949f-a5868040a702.png"/> <img width="230" src="https://user-images.githubusercontent.com/62925639/182159563-0eeedaa7-5cc3-40e4-9024-3fb75a799d79.png"/> 

> 생일 빈 스트링 입력, 에러 메세지 출력 화면

<img width="230" src="https://user-images.githubusercontent.com/62925639/182159568-814bd5eb-3150-48c4-813d-1e3862cc12ec.png"/> <img width="230" src="https://user-images.githubusercontent.com/62925639/182159572-866f1cdb-556d-4774-bff5-a7ecc4fe2739.png"/> <img width="230" src="https://user-images.githubusercontent.com/62925639/182159575-694d7355-ddbd-46dc-9bb2-b84b2a4c27f5.png"/>
