### PR TITLE
[APP] `SignUpRIB`과 `SignInRIB`을 연결하고, 뒤로가기 시 `detach`가 되지 않는 에러를 수정했어요.

### DIFF
--- a/SixthSense/Account/Sources/Extensions/ViewControllable+Utils.swift
+++ b/SixthSense/Account/Sources/Extensions/ViewControllable+Utils.swift
@@ -31,7 +31,9 @@ public extension ViewControllable {
     }
     
     func dismiss(completion: (() -> Void)?) {
-        self.uiviewController.dismiss(animated: true, completion: completion)
+        if self.uiviewController.presentedViewController === self.uiviewController {
+            self.uiviewController.dismiss(animated: true, completion: completion)
+        }
     }
     
     func pushViewController(_ viewControllable: ViewControllable, animated: Bool) {

--- a/SixthSense/Account/Sources/Extensions/ViewControllable+Utils.swift
+++ b/SixthSense/Account/Sources/Extensions/ViewControllable+Utils.swift
@@ -30,10 +30,8 @@ public extension ViewControllable {
         self.uiviewController.present(viewControllable.uiviewController, animated: animated, completion: completion)
     }
     
-    func dismiss(completion: (() -> Void)?) {
-        if self.uiviewController.presentedViewController === self.uiviewController {
-            self.uiviewController.dismiss(animated: true, completion: completion)
-        }
+    func dismiss(animated: Bool, completion: (() -> Void)?) {
+        self.uiviewController.dismiss(animated: animated, completion: completion)
     }
     
     func pushViewController(_ viewControllable: ViewControllable, animated: Bool) {

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
@@ -12,6 +12,7 @@ import AuthenticationServices
 
 public protocol SignInRouting: ViewableRouting {
     func routeToSignUp(payload: SignUpPayload)
+    func detachSignUp()
 }
 
 protocol SignInPresentable: Presentable {
@@ -66,5 +67,9 @@ final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInIn
 
     func skip() {
         listener?.signInDidTapClose()
+    }
+
+    func returnToSignIn() {
+        router?.detachSignUp()
     }
 }

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
@@ -41,8 +41,8 @@ final class SignInRouter: ViewableRouter<SignInInteractable, SignInViewControlla
 
     func detachSignUp() {
         guard let router = childRouting else { return }
-        router.viewControllable.dismiss(animated: false, completion: nil)
-        self.childRouting = nil
         detachChild(router)
+        viewController.dismiss(animated: false, completion: nil)
+        self.childRouting = nil
     }
 }

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
@@ -34,8 +34,15 @@ final class SignInRouter: ViewableRouter<SignInInteractable, SignInViewControlla
         let router = signUpBuilder.build(withListener: self.interactor, payload: payload)
         let viewController = router.viewControllable
         viewController.uiviewController.modalPresentationStyle = .fullScreen
-        viewControllable.present(viewController, animated: false)
-        attachChild(router)
+        viewControllable.present(viewController, animated: false, completion: nil)
         self.childRouting = router
+        attachChild(router)
+    }
+
+    func detachSignUp() {
+        guard let router = childRouting else { return }
+        router.viewControllable.dismiss(completion: nil)
+        self.childRouting = nil
+        detachChild(router)
     }
 }

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInRouter.swift
@@ -41,7 +41,7 @@ final class SignInRouter: ViewableRouter<SignInInteractable, SignInViewControlla
 
     func detachSignUp() {
         guard let router = childRouting else { return }
-        router.viewControllable.dismiss(completion: nil)
+        router.viewControllable.dismiss(animated: false, completion: nil)
         self.childRouting = nil
         detachChild(router)
     }

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -107,8 +107,6 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
     override func willResignActive() {
         super.willResignActive()
         presenter.listener = nil
-        presenter.handler = nil
-        presenter.action = nil
     }
 
     private func doSignUp() {

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -49,12 +49,14 @@ protocol SignUpPresenterHandler: AnyObject {
 protocol SignUpPresentable: Presentable {
     var handler: SignUpPresenterHandler? { get set }
     var action: SignUpPresenterAction? { get set }
-    var listener: SignUpListener? { get set }
+    var listener: SignUpPresentableListener? { get set }
 }
 
-public protocol SignUpListener: AnyObject { }
+public protocol SignUpListener: AnyObject {
+    func returnToSignIn()
+}
 
-final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpInteractable, SignUpListener {
+final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpInteractable, SignUpPresentableListener {
 
     weak var router: SignUpRouting?
     weak var listener: SignUpListener?

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -58,6 +58,10 @@ public protocol SignUpListener: AnyObject {
 
 final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpInteractable, SignUpPresentableListener {
 
+    func didTapBackButton() {
+        listener?.returnToSignIn()
+    }
+
     weak var router: SignUpRouting?
     weak var listener: SignUpListener?
 
@@ -102,6 +106,8 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
 
     override func willResignActive() {
         super.willResignActive()
+        presenter.listener = nil
+        presenter.handler = nil
     }
 
     private func doSignUp() {

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -108,6 +108,7 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
         super.willResignActive()
         presenter.listener = nil
         presenter.handler = nil
+        presenter.action = nil
     }
 
     private func doSignUp() {

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -106,7 +106,6 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
 
     override func willResignActive() {
         super.willResignActive()
-        presenter.listener = nil
     }
 
     private func doSignUp() {

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -22,8 +22,8 @@ protocol SignUpPresentableListener: AnyObject {
 final class SignUpViewController: UIViewController, SignUpPresentable, SignUpViewControllable {
 
     var listener: SignUpPresentableListener?
-    var action: SignUpPresenterAction?
-    var handler: SignUpPresenterHandler?
+    weak var action: SignUpPresenterAction?
+    weak var handler: SignUpPresenterHandler?
 
     // MARK: - UI
 
@@ -83,9 +83,12 @@ final class SignUpViewController: UIViewController, SignUpPresentable, SignUpVie
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureUI()
         bindUI()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
     }
 }
 
@@ -157,14 +160,13 @@ private extension SignUpViewController {
 
         rx.viewDidLayoutSubviews
             .take(1)
-            .bind(onNext: {
-            self.configureLayout()
+            .bind(onNext: { [weak self] in
+            self?.configureLayout()
         }).disposed(by: disposeBag)
 
         signUpPageView.stepDrvier
             .drive(onNext: { [weak self] in
-            guard let self = self else { return }
-            self.stepChanged($0)
+            self?.stepChanged($0)
         }).disposed(by: disposeBag)
 
         backButton.rx.tap
@@ -206,7 +208,8 @@ private extension SignUpViewController {
 
     private func handleGenderSubView(with handler: SignUpPresenterHandler) {
         handler.genderInputValid
-            .bind(onNext: { tag in
+            .bind(onNext: { [weak self] tag in
+            guard let self = self else { return }
             let vc = self.signUpPageView.genderInputView
             vc.selectButtons.forEach {
                 if $0.tag == tag {

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -15,9 +15,13 @@ import RxKeyboard
 import Then
 import UIKit
 
+protocol SignUpPresentableListener: AnyObject {
+    func didTapBackButton()
+}
+
 final class SignUpViewController: UIViewController, SignUpPresentable, SignUpViewControllable {
 
-    var listener: SignUpListener?
+    var listener: SignUpPresentableListener?
     var action: SignUpPresenterAction?
     var handler: SignUpPresenterHandler?
 
@@ -308,6 +312,7 @@ private extension SignUpViewController {
         switch step {
         case .exit:
             // TODO: SignIn RIB 연결
+            listener?.didTapBackButton()
             return
         case .nickname:
             stepProgressLabel.text = "\(Int(progressPositions[0] * 100))%"

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpViewController.swift
@@ -21,7 +21,7 @@ protocol SignUpPresentableListener: AnyObject {
 
 final class SignUpViewController: UIViewController, SignUpPresentable, SignUpViewControllable {
 
-    var listener: SignUpPresentableListener?
+    weak var listener: SignUpPresentableListener?
     weak var action: SignUpPresenterAction?
     weak var handler: SignUpPresenterHandler?
 

--- a/SixthSense/Account/Sources/SignUp/Presentation/SubViews/BirthStepViewController.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SubViews/BirthStepViewController.swift
@@ -7,8 +7,6 @@
 //
 
 import UIKit
-import RxSwift
-import RxGesture
 import Then
 import DesignSystem
 
@@ -59,7 +57,6 @@ final class BirthStepViewController: UIViewController {
 
     // MARK: - Vars
     let birthTextFields: [AppTextField]
-    private let disposeBag = DisposeBag()
 
     // MARK: - LifeCycle
 


### PR DESCRIPTION
- Resolved #52 
---

### 설명
`SignUpRIB`에서 `dismiss` 했을때  `SignUpViewController`가 `detach`되지 않던 에러 수정했어요.


### 작업사항
- [X] : `SignUpInteractor`에 `listener`를 연결해서 `SignInRouting`으로 이동 후 `detach` 처리
- [X] : `ViewControllerable extension`에 `dismiss` 메소드 수정
- [X] : `SignUpViewController`의 `handler, action, listener` 모두 `weak` 처리
```swift
/// SignUpViewController.swift

    final class SignUpViewController: UIViewController, SignUpPresentable, SignUpViewControllable {

        weak var listener: SignUpPresentableListener?
        weak var action: SignUpPresenterAction?
        weak var handler: SignUpPresenterHandler?

        .
        .
        .
    }

```

### 스크린샷

https://user-images.githubusercontent.com/62925639/183281307-54a68749-1175-4663-902a-68b649f2e834.mp4


