### PR TITLE
[App] 캘린더-리스트 간 글로벌 스트림을 구성하고 날짜 선택 시 리스트 패치를 돌리는 로직을 구성했어요

### DIFF
--- a/SixthSense/Home/Sources/Challenge/ChallengeBuilder.swift
+++ b/SixthSense/Home/Sources/Challenge/ChallengeBuilder.swift
@@ -7,12 +7,21 @@
 //
 
 import RIBs
+import RxRelay
+import Foundation
 
 protocol ChallengeDependency: Dependency { }
 
 final class ChallengeComponent: Component<ChallengeDependency>,
                                 ChallengeCalendarDependency,
-                                ChallengeListDependency { }
+                                ChallengeListDependency {
+    var targetDate: PublishRelay<Date>
+    
+    override init(dependency: ChallengeDependency) {
+        targetDate = .init()
+        super.init(dependency: dependency)
+    }
+}
 
 // MARK: - Builder
 

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarBuilder.swift
@@ -7,15 +7,16 @@
 //
 
 import RIBs
+import RxRelay
+import Foundation
 
 protocol ChallengeCalendarDependency: Dependency {
-    // TODO: Declare the set of dependencies required by this RIB, but cannot be
-    // created by this RIB.
+    var targetDate: PublishRelay<Date> { get }
 }
 
-final class ChallengeCalendarComponent: Component<ChallengeCalendarDependency> {
-
-    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+final class ChallengeCalendarComponent: Component<ChallengeCalendarDependency>,
+                                        ChallengeCalendarInteractorDependency{
+    var targetDate: PublishRelay<Date> { dependency.targetDate }
 }
 
 // MARK: - Builder
@@ -33,7 +34,7 @@ final class ChallengeCalendarBuilder: Builder<ChallengeCalendarDependency>, Chal
     func build(withListener listener: ChallengeCalendarListener) -> ChallengeCalendarRouting {
         let component = ChallengeCalendarComponent(dependency: dependency)
         let viewController = ChallengeCalendarViewController()
-        let interactor = ChallengeCalendarInteractor(presenter: viewController)
+        let interactor = ChallengeCalendarInteractor(presenter: viewController, dependency: component)
         interactor.listener = listener
         return ChallengeCalendarRouter(interactor: interactor, viewController: viewController)
     }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarInteractor.swift
@@ -34,13 +34,17 @@ protocol ChallengeCalendarPresentable: Presentable {
     var action: ChallengeCalendarPresenterAction? { get set }
 }
 
+protocol ChallengeCalendarInteractorDependency {
+    var targetDate: PublishRelay<Date> { get }
+}
+
 protocol ChallengeCalendarListener: AnyObject { }
 
 final class ChallengeCalendarInteractor: PresentableInteractor<ChallengeCalendarPresentable>, ChallengeCalendarInteractable {
 
     weak var router: ChallengeCalendarRouting?
     weak var listener: ChallengeCalendarListener?
-    
+    private let dependency: ChallengeCalendarInteractorDependency
     
     private let basisDateRelay: BehaviorRelay<Date> = .init(value: Date())
     private let calendarDataSourceRelay: PublishRelay<[[Int]]> = .init()
@@ -50,7 +54,9 @@ final class ChallengeCalendarInteractor: PresentableInteractor<ChallengeCalendar
     // FIXME: 개발 후에 DI로 주입하도록 변경할거에요
     private let factory: ChallengeCalendarFactory = ChallengeCalendarFactoryImpl()
     
-    override init(presenter: ChallengeCalendarPresentable) {
+    init(presenter: ChallengeCalendarPresentable,
+         dependency: ChallengeCalendarInteractorDependency) {
+        self.dependency = dependency
         super.init(presenter: presenter)
         presenter.handler = self
     }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarInteractor.swift
@@ -20,6 +20,7 @@ protocol ChallengeCalendarPresenterAction: AnyObject {
     var swipeCalendar: Observable<Date> { get }
     var monthBeginEditing: Observable<(row: Int, component: Int)> { get }
     var monthDidSelected: Observable<Void> { get }
+    var dateDidSelected: Observable<Date> { get }
 }
 
 protocol ChallengeCalendarPresenterHandler: AnyObject {
@@ -108,6 +109,16 @@ final class ChallengeCalendarInteractor: PresentableInteractor<ChallengeCalendar
                 owner.basisDateRelay.accept(owner.calendarConfiguration.basisDate)
             })
             .disposeOnDeactivate(interactor: self)
+        
+        action.dateDidSelected
+            .withUnretained(self)
+            .subscribe(onNext: { owner, date in
+                owner.dependency.targetDate.accept(date)
+            })
+            .disposeOnDeactivate(interactor: self)
+    }
+}
+
 // TODO: 파일로 분리
 protocol ChallengeCalendarFactory {
     var dayChallengeState: (Date) -> ChallengeCalendarDayState { get }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController+Calendar.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController+Calendar.swift
@@ -31,6 +31,10 @@ extension ChallengeCalendarViewController: JTACMonthViewDelegate {
         return cell
     }
     
+    func calendar(_ calendar: JTACMonthView, didSelectDate date: Date, cell: JTACDayCell?, cellState: CellState, indexPath: IndexPath) {
+        dateSelectRelay.accept(date)
+    }
+    
     func calendar(_ calendar: JTACMonthView, didScrollToDateSegmentWith visibleDates: DateSegmentInfo) {
         let target: Date = visibleDates.monthDates.last?.date ?? .init()
         swipeCalendarRelay.accept(target)

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
@@ -28,6 +28,8 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
     }
     
     let swipeCalendarRelay: PublishRelay<Date> = .init()
+    let dateSelectRelay: PublishRelay<Date> = .init()
+    
     private let disposeBag = DisposeBag()
     private let pickerAdapter = RxPickerViewStringAdapter<[[Int]]>(
         components: [],
@@ -179,4 +181,5 @@ extension ChallengeCalendarViewController: ChallengeCalendarPresenterAction {
     }
     var monthDidSelected: Observable<Void> { doneButton.rx.tap.asObservable() }
     var swipeCalendar: Observable<Date> { swipeCalendarRelay.asObservable() }
+    var dateDidSelected: Observable<Date> { dateSelectRelay.asObservable() }
 }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListBuilder.swift
@@ -7,15 +7,16 @@
 //
 
 import RIBs
+import RxRelay
+import Foundation
 
 protocol ChallengeListDependency: Dependency {
-    // TODO: Declare the set of dependencies required by this RIB, but cannot be
-    // created by this RIB.
+    var targetDate: PublishRelay<Date> { get }
 }
 
-final class ChallengeListComponent: Component<ChallengeListDependency> {
-
-    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+final class ChallengeListComponent: Component<ChallengeListDependency>,
+                                    ChallengeListInteractorDependency {
+    var targetDate: PublishRelay<Date> { dependency.targetDate }
 }
 
 // MARK: - Builder
@@ -33,7 +34,7 @@ final class ChallengeListBuilder: Builder<ChallengeListDependency>, ChallengeLis
     func build(withListener listener: ChallengeListListener) -> ChallengeListRouting {
         let component = ChallengeListComponent(dependency: dependency)
         let viewController = ChallengeListViewController()
-        let interactor = ChallengeListInteractor(presenter: viewController)
+        let interactor = ChallengeListInteractor(presenter: viewController, dependency: component)
         interactor.listener = listener
         return ChallengeListRouter(interactor: interactor, viewController: viewController)
     }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -61,14 +61,18 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
         action.viewDidAppear
             .subscribe(onNext: { [weak self] in
                 self?.makeSections()
+        dependency.targetDate
+            .withUnretained(self)
+            .subscribe(onNext: { owner, date in
+                owner.fetch(by: date)
             })
             .disposeOnDeactivate(interactor: self)
     }
     
-    private func makeSections() {
+    private func fetch(by date: Date) {
         // TODO: 미완성된 기능입니다
         sectionsRelay.accept([.init(identity: .item, items: [.item("하루 채식"),
-            .item("하루 채식"),
+            .item("하루 \(date)채식"),
             .item("하루 채식"),
             .item("하루 채식"),
             .item("하루 채식"),

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -9,6 +9,7 @@
 import RIBs
 import RxSwift
 import RxRelay
+import Foundation
 
 protocol ChallengeListRouting: ViewableRouting {}
 
@@ -28,14 +29,20 @@ protocol ChallengeListPresentable: Presentable {
 protocol ChallengeListListener: AnyObject {
 }
 
+protocol ChallengeListInteractorDependency {
+    var targetDate: PublishRelay<Date> { get }
+}
+
 final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresentable>,
                                      ChallengeListInteractable {
     weak var router: ChallengeListRouting?
     weak var listener: ChallengeListListener?
+    private let dependency: ChallengeListInteractorDependency
     
     private let sectionsRelay: PublishRelay<[ChallengeSection]> = .init()
     
-    override init(presenter: ChallengeListPresentable) {
+    init(presenter: ChallengeListPresentable, dependency: ChallengeListInteractorDependency) {
+        self.dependency = dependency
         super.init(presenter: presenter)
         presenter.handler = self
     }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -59,8 +59,13 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
     private func bind() {
         guard let action = presenter.action else { return }
         action.viewDidAppear
-            .subscribe(onNext: { [weak self] in
-                self?.makeSections()
+            .take(1)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, _ in
+                owner.fetch(by: Date())
+            })
+            .disposeOnDeactivate(interactor: self)
+        
         dependency.targetDate
             .withUnretained(self)
             .subscribe(onNext: { owner, date in


### PR DESCRIPTION
### 설명
캘린더와 리스트 리블렛 상위 립에 `targetDate` PublishRelay를 구성하고 캘린더에서 상태가 방출되면
리스트에서 구독해서 패치돌리는 로직을 구현하였어요

### 스크린샷
* 테스트 데이터로 2번째 아이템에 선택된 날짜를 표시하도록 했어요

https://user-images.githubusercontent.com/69489688/184604762-6afffc1e-4428-44a8-b364-72deac72386c.MP4


