### PR TITLE
[Challenge] 챌린지 등록 API를 연결했어요

### DIFF
--- a/SixthSense/Home/Sources/ChallengeRegister/Domain/UseCases/ChallengeRegisterUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeRegister/Domain/UseCases/ChallengeRegisterUseCase.swift
@@ -13,6 +13,7 @@ import Repository
 public protocol ChallengeRegisterUseCase {
     func fetchChallengeCategories() -> Observable<[CategoryModel]>
     func fetchChallengeRegisterLists() -> Observable<[ChallengeRegisterModel]>
+    func joinChallenge(request: ChallengeJoinRequest) -> Observable<String>
 }
 
 final class ChallengeRegisterUseCaseImpl: ChallengeRegisterUseCase {
@@ -31,5 +32,9 @@ final class ChallengeRegisterUseCaseImpl: ChallengeRegisterUseCase {
     func fetchChallengeRegisterLists() -> Observable<[ChallengeRegisterModel]> {
         return challengeRepository.registerLists()
             .compactMap({ DataModel<ChallengeRegisterModel>(JSONString: $0)?.data }).asObservable()
+    }
+
+    func joinChallenge(request: ChallengeJoinRequest) -> Observable<String> {
+        return challengeRepository.joinChallenge(request: request).asObservable()
     }
 }

--- a/SixthSense/Repository/Sources/Challnege/ChallengeAPI.swift
+++ b/SixthSense/Repository/Sources/Challnege/ChallengeAPI.swift
@@ -14,6 +14,7 @@ enum ChallengeAPI {
     case categoryLists
     case registerLists
     case recommendLists(String)
+    case joinChallenge(ChallengeJoinRequest)
 }
 
 extension ChallengeAPI: BaseAPI, AccessTokenAuthorizable {
@@ -30,11 +31,15 @@ extension ChallengeAPI: BaseAPI, AccessTokenAuthorizable {
             return "/challenge/list"
         case .recommendLists(let itemId):
             return "/challenge/guide/\(itemId)"
+        case .joinChallenge:
+            return "/challenge/join"
         }
     }
 
     var method: Moya.Method {
         switch self {
+        case .joinChallenge:
+            return .post
         default:
             return .get
         }
@@ -49,6 +54,11 @@ extension ChallengeAPI: BaseAPI, AccessTokenAuthorizable {
         let body: [String: Any] = [:]
 
         switch self {
+        case .joinChallenge(let request):
+            return .requestCompositeParameters(
+                bodyParameters: request.asBody(body),
+                bodyEncoding: parameterEncoding,
+                urlParameters: parameters)
         default:
             return .requestPlain
         }
@@ -64,6 +74,8 @@ extension ChallengeAPI: BaseAPI, AccessTokenAuthorizable {
 
     var parameterEncoding: ParameterEncoding {
         switch self {
+        case .joinChallenge:
+            return JSONEncoding.default
         default:
             return URLEncoding.queryString
         }

--- a/SixthSense/Repository/Sources/Challnege/ChallengeRepository.swift
+++ b/SixthSense/Repository/Sources/Challnege/ChallengeRepository.swift
@@ -13,4 +13,5 @@ public protocol ChallengeRepository: AnyObject {
     func categoryLists() -> Single<String>
     func registerLists() -> Single<String>
     func recommendLists(itemId: String) -> Single<String>
+    func joinChallenge(request: ChallengeJoinRequest) -> Single<String>
 }

--- a/SixthSense/Repository/Sources/Challnege/ChallengeRepositoryImpl.swift
+++ b/SixthSense/Repository/Sources/Challnege/ChallengeRepositoryImpl.swift
@@ -40,4 +40,12 @@ public final class ChallengeRepositoryImpl: ChallengeRepository {
             return .just(data)
         }
     }
+
+    public func joinChallenge(request: ChallengeJoinRequest) -> Single<String> {
+        return network.request(ChallengeAPI.joinChallenge(request))
+            .mapString()
+            .flatMap { data -> Single<String> in
+            return .just("")
+        }
+    }
 }

--- a/SixthSense/Repository/Sources/Challnege/Requests/ChallengeJoinRequest.swift
+++ b/SixthSense/Repository/Sources/Challnege/Requests/ChallengeJoinRequest.swift
@@ -1,0 +1,46 @@
+//
+//  ChallengeJoinRequest.swift
+//  Repository
+//
+//  Created by Allie Kim on 2022/08/30.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import Then
+import ObjectMapper
+
+public struct ChallengeJoinRequest: Mappable {
+
+    public var challengeDate: String
+    public var challengeId: Int
+
+    public init() {
+        challengeDate = ""
+        challengeId = -1
+    }
+
+    public init(date: String, challengeId: Int) {
+        challengeDate = date
+        self.challengeId = challengeId
+    }
+
+    public init?(map: Map) {
+        challengeDate = ""
+        challengeId = -1
+    }
+
+    mutating public func mapping(map: Map) {
+        challengeDate <- map["challengeDate"]
+        challengeId <- map["challengeId"]
+    }
+
+    func asBody(_ defaultBody: [String: Any]) -> [String: Any] {
+        return defaultBody.with {
+            $0.merge(dict: [
+                "challengeDate": challengeDate,
+                "challengeId": challengeId
+            ])
+        }
+    }
+}

--- a/SixthSense/Repository/Sources/User/Requests/SignUpRequest.swift
+++ b/SixthSense/Repository/Sources/User/Requests/SignUpRequest.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Then
 import ObjectMapper
 
 public struct SignUpRequest: Mappable {


### PR DESCRIPTION
- Resolved #102 
---

### 설명
> 챌린지를 선택하고 버튼을 누르면 챌린지를 등록하고 recommend list 화면으로 전환했어요.


### 작업사항
- [x] : `/challenge/join` API 연결

### 스크린샷
> id가 4인 챌린지를 선택하고 4번에 해당하는 추천 리스트를 불러왔어요

https://user-images.githubusercontent.com/62925639/187470737-3cd11348-5815-4627-a2f8-9d20eae4746d.mov


### 기타사항
- 에러팝업 UI 나오면 적용해야 합니다.
