### PR TITLE
[App] 챌린지리스트 | 삭제 컨펌알럿과 삭제로직을 구현했어요

### DIFF
--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -178,6 +178,7 @@ extension ChallengeSectionItem: RawRepresentable {
 
 extension ChallengeItemCellViewModel {
     init(item: ChallengeItem) {
+        self.id = item.id
         self.emoji = item.emoji
         self.title = item.title
     }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -56,6 +56,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
     private let dependency: ChallengeListInteractorDependency
     
     private var sectionsItem: [ChallengeSection] = []
+    private var targetDate: Date = .init()
     
     private let sectionsRelay: PublishRelay<[ChallengeSection]> = .init()
     private let hasItemRelay: PublishRelay<Bool> = .init()
@@ -95,6 +96,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
         dependency.targetDate
             .withUnretained(self)
             .subscribe(onNext: { owner, date in
+                owner.targetDate = date
                 owner.fetch(by: date)
             })
             .disposeOnDeactivate(interactor: self)

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -29,6 +29,7 @@ protocol ChallengeListPresenterAction: AnyObject {
 protocol ChallengeListPresenterHandler: AnyObject {
     var sections: Observable<[ChallengeSection]> { get }
     var hasItem: Observable<Bool> { get }
+    var showToast: Observable<String> { get }
 }
 
 protocol ChallengeListPresentable: Presentable {
@@ -61,6 +62,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
     
     private let sectionsRelay: PublishRelay<[ChallengeSection]> = .init()
     private let hasItemRelay: PublishRelay<Bool> = .init()
+    private let showToastRelay: PublishRelay<String> = .init()
     
     init(presenter: ChallengeListPresentable, dependency: ChallengeListInteractorDependency) {
         self.dependency = dependency
@@ -167,6 +169,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.fetch(by: owner.targetDate)
+                owner.showToastRelay.accept("챌린지 삭제가 완료되었어요")
             })
             .disposeOnDeactivate(interactor: self)
     }
@@ -186,6 +189,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
 extension ChallengeListInteractor: ChallengeListPresenterHandler {
     var sections: Observable<[ChallengeSection]> { sectionsRelay.asObservable() }
     var hasItem: Observable<Bool> { hasItemRelay.asObservable() }
+    var showToast: Observable<String> { showToastRelay.asObservable() }
 }
 
 extension ChallengeSectionItem: RawRepresentable {

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
@@ -146,14 +146,18 @@ extension ChallengeListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         switch dataSource[indexPath.section].items[indexPath.row] {
             case .success, .failed, .waiting:
-                return configureSwipeDeleteButton()
+                return configureSwipeDeleteButton(indexPath: indexPath)
             case .add, .spacing:
                 return UISwipeActionsConfiguration(actions: [])
         }
     }
     
-    private func configureSwipeDeleteButton() -> UISwipeActionsConfiguration? {
-        let delete = UIContextualAction(style: .normal, title: nil) { (contextualAction, view, completion) in completion(true) }.then {
+    private func configureSwipeDeleteButton(indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let delete = UIContextualAction(style: .normal, title: nil) { [weak self] (contextualAction, view, completion) in
+            self?.showDeleteConfirmAlert(indexPath: indexPath)
+            completion(true)
+            
+        }.then {
             $0.image = UIImage(systemName: "trash",
                                withConfiguration: UIImage.SymbolConfiguration(
                                 pointSize: 16,
@@ -165,6 +169,20 @@ extension ChallengeListViewController: UITableViewDelegate {
         return UISwipeActionsConfiguration(actions: [delete]).then {
             $0.performsFirstActionWithFullSwipe = true
         }
+    }
+    
+    
+    private func showDeleteConfirmAlert(indexPath: IndexPath) {
+        showAlert(title: "챌린지를 삭제할거야?",
+                        message: "삭제한 챌린지는 다시 찾을 수 없어요😥",
+                        actions: [.action(title: "앗.. 잠시만!", style: .negative),
+                                  .action(title: "응, 삭제할게", style: .positive)])
+        .filter { $0 == .positive }
+        .withUnretained(self)
+        .subscribe(onNext: { owner, _ in
+            owner.itemDeleteRelay.accept(indexPath)
+        })
+        .disposed(by: self.disposeBag)
     }
 }
 

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
@@ -8,6 +8,7 @@
 
 import RIBs
 import RxSwift
+import RxRelay
 import UIKit
 import RxAppState
 import RxDataSources
@@ -20,6 +21,8 @@ final class ChallengeListViewController: UIViewController, ChallengeListPresenta
     private let disposeBag = DisposeBag()
     weak var handler: ChallengeListPresenterHandler?
     weak var action: ChallengeListPresenterAction?
+    
+    private let itemDeleteRelay: PublishRelay<IndexPath> = .init()
     
     private enum Constants { }
     
@@ -170,4 +173,5 @@ extension ChallengeListViewController: ChallengeListPresenterAction {
     var viewDidAppear: Observable<Void> { rx.viewDidAppear.asObservable().map { _ in () } }
     var itemSelected: Observable<IndexPath> { tableView.rx.itemSelected
         .flatMap { index -> Observable<IndexPath> in .just(index)} }
+    var itemDidDeleted: Observable<IndexPath> { itemDeleteRelay.asObservable() }
 }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
@@ -116,6 +116,13 @@ final class ChallengeListViewController: UIViewController, ChallengeListPresenta
                 self?.listVisible(hasItem)
             })
             .disposed(by: self.disposeBag)
+        
+        handler.showToast
+            .asDriver(onErrorJustReturn: .init())
+            .drive(onNext: { [weak self] in
+                self?.showToast($0)
+            })
+            .disposed(by: self.disposeBag)
     }
 }
 

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -17,16 +17,17 @@ struct ChallengeListUseCaseImpl: ChallengeListUseCase {
     func list(by date: Date) -> Observable<[ChallengeItem]> {
         // TODO: 테스트 코드 제거
         return .just([
-            .init(emoji: "🦊", title: "하루 채식", status: .success),
-            .init(emoji: "📆", title: "\(date)", status: .failed),
-            .init(emoji: "🥬", title: "하루 채식", status: .success),
-            .init(emoji: "🥵", title: "하루 채식", status: .waiting),
+            .init(id: "아이디아이디1", emoji: "🦊", title: "하루 채식", status: .success),
+            .init(id: "아이디아이디2", emoji: "📆", title: "\(date)", status: .failed),
+            .init(id: "아이디아이디3", emoji: "🥬", title: "하루 채식", status: .success),
+            .init(id: "아이디아이디4", emoji: "🥵", title: "하루 채식", status: .waiting),
         ])
     }
 }
 
 // TODO: 서버 스펙 확정후 엔티티 확정하면서 파일로 분리할 예정
 struct ChallengeItem {
+    let id: String
     let emoji: String
     let title: String
     let status: ChallengeAchievedStatus

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 protocol ChallengeListUseCase {
     func list(by date: Date) -> Observable<[ChallengeItem]>
+    func delete(id: String) -> Observable<Void>
 }
 
 struct ChallengeListUseCaseImpl: ChallengeListUseCase {
@@ -22,6 +23,11 @@ struct ChallengeListUseCaseImpl: ChallengeListUseCase {
             .init(id: "아이디아이디3", emoji: "🥬", title: "하루 채식", status: .success),
             .init(id: "아이디아이디4", emoji: "🥵", title: "하루 채식", status: .waiting),
         ])
+    }
+    
+    func delete(id: String) -> Observable<Void> {
+        // TODO: 테스트 코드 제거
+        return .just(())
     }
 }
 

--- a/SixthSense/Home/Sources/ChallengeList/Views/ChallengeItemCellViewModel.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Views/ChallengeItemCellViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct ChallengeItemCellViewModel {
+    let id: String
     let emoji: String
     let title: String
 }


### PR DESCRIPTION
### 설명
- 컨펌알럿을 띄우는 로직을 구현했어요 인터렉터에 책임을 물리는것보다 컨펌 알럿을 뷰내에 하나의 UI적 요소로 보고
뷰에 책임을 물렸어요
-  리스트의 타겟날짜를 인터렉터에 상태를 저장하도록 했어요 (삭제 후 다시 패치 돌리기 위함)

### 스크린샷
https://user-images.githubusercontent.com/69489688/189097240-cfe51da6-1297-4617-b641-d0749c42902b.MP4



