### PR TITLE
[App] 인증등록 화면에 API를 붙히고 에러토스트 로직을 추가했어요

### DIFF
--- a/SixthSense/Challenge/Sources/Check/ChallengeCheck.swift
+++ b/SixthSense/Challenge/Sources/Check/ChallengeCheck.swift
@@ -1,0 +1,59 @@
+//
+//  ChallengeCheck.swift
+//  Challenge
+//
+//  Created by 문효재 on 2022/09/10.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import ObjectMapper
+
+// TODO: 나중에 공통파일로 분리해요
+protocol Responsable {
+    init()
+}
+
+struct Response<T: Responsable & Mappable>: Mappable {
+    var data: T
+    
+    init() {
+        data = .init()
+    }
+    
+    init?(map: Map) {
+        self.init()
+    }
+    
+    mutating func mapping(map: Map) {
+        data <- map["data"]
+    }
+}
+
+struct ChallengeCheck: Mappable, Responsable {
+    var userChallengeID: Int
+    var date: String
+    var challengeID: Int
+    var contentImage: String
+    var titleImage: String
+    
+    init() {
+        userChallengeID = -1
+        date = ""
+        challengeID = -1
+        contentImage = ""
+        titleImage = ""
+    }
+    
+    init?(map: Map) {
+        self.init()
+    }
+    
+    mutating func mapping(map: Map) {
+        userChallengeID <- map["userChallengeId"]
+        date <- map["challengeDate"]
+        challengeID <- map["challengeId"]
+        contentImage <- map["contentImage"]
+        titleImage <- map["titleImage"]
+    }
+}

--- a/SixthSense/Challenge/Sources/Check/ChallengeCheckBuilder.swift
+++ b/SixthSense/Challenge/Sources/Check/ChallengeCheckBuilder.swift
@@ -7,17 +7,17 @@
 //
 
 import RIBs
+import Repository
 
 public protocol ChallengeCheckDependency: Dependency {
-    // TODO: Declare the set of dependencies required by this RIB, but cannot be
-    // created by this RIB.
+    var userChallengeRepository: UserChallengeRepository { get }
 }
 
 final class ChallengeCheckComponent: Component<ChallengeCheckDependency>, ChallengeCheckInteractorDependency {
     var usecase: ChallengeCheckUseCase
     
     override init(dependency: ChallengeCheckDependency) {
-        usecase = ChallengeCheckUseCaseImpl()
+        usecase = ChallengeCheckUseCaseImpl(repository: dependency.userChallengeRepository)
         super.init(dependency: dependency)
     }
 }
@@ -25,7 +25,7 @@ final class ChallengeCheckComponent: Component<ChallengeCheckDependency>, Challe
 // MARK: - Builder
 
 public protocol ChallengeCheckBuildable: Buildable {
-    func build(withListener listener: ChallengeCheckListener) -> ChallengeCheckRouting
+    func build(withListener listener: ChallengeCheckListener, id: Int) -> ChallengeCheckRouting
 }
 
 public final class ChallengeCheckBuilder: Builder<ChallengeCheckDependency>, ChallengeCheckBuildable {
@@ -34,10 +34,12 @@ public final class ChallengeCheckBuilder: Builder<ChallengeCheckDependency>, Cha
         super.init(dependency: dependency)
     }
 
-    public func build(withListener listener: ChallengeCheckListener) -> ChallengeCheckRouting {
+    public func build(withListener listener: ChallengeCheckListener, id: Int) -> ChallengeCheckRouting {
         let component = ChallengeCheckComponent(dependency: dependency)
         let viewController = ChallengeCheckViewController()
-        let interactor = ChallengeCheckInteractor(presenter: viewController, dependency: component)
+        let interactor = ChallengeCheckInteractor(presenter: viewController,
+                                                  id: id,
+                                                  dependency: component)
         interactor.listener = listener
         return ChallengeCheckRouter(interactor: interactor, viewController: viewController)
     }

--- a/SixthSense/Challenge/Sources/Check/ChallengeCheckInteractor.swift
+++ b/SixthSense/Challenge/Sources/Check/ChallengeCheckInteractor.swift
@@ -24,6 +24,7 @@ protocol ChallengeCheckPresenterAction: AnyObject {
 protocol ChallengeCheckPresenterHandler: AnyObject {
     var doneButtonActive: Observable<Bool> { get }
     var showDonePopUp: Observable<ChallengeCheckComplete> { get }
+    var errorMessage: Observable<String> { get }
 }
 
 protocol ChallengeCheckPresentable: Presentable {
@@ -50,6 +51,7 @@ final class ChallengeCheckInteractor: PresentableInteractor<ChallengeCheckPresen
     
     private let doneButtonActiveRelay: PublishRelay<Bool> = .init()
     private let showDonePopUpRelay: PublishRelay<ChallengeCheckComplete> = .init()
+    private let errorMessageRelay: PublishRelay<String> = .init()
 
     init(presenter: ChallengeCheckPresentable,
          id: Int,
@@ -94,16 +96,25 @@ final class ChallengeCheckInteractor: PresentableInteractor<ChallengeCheckPresen
     }
     
     private func registerChallenge(request: ChallengeCheckRequest) {
-        dependency.usecase.register(request: request)
+        dependency.usecase.register(id: id, request: request)
+            .catch { [weak self] error in
+                self?.toastMessage(error.localizedDescription)
+                return .empty()
+            }
             .withUnretained(self)
             .subscribe(onNext: { owner, response in
                 owner.showDonePopUpRelay.accept(response)
             })
             .disposeOnDeactivate(interactor: self)
     }
+    
+    private func toastMessage(_ message: String) {
+        errorMessageRelay.accept(message)
+    }
 }
 
 extension ChallengeCheckInteractor: ChallengeCheckPresenterHandler {
     var doneButtonActive: Observable<Bool> { doneButtonActiveRelay.asObservable() }
     var showDonePopUp: Observable<ChallengeCheckComplete> { showDonePopUpRelay.asObservable() }
+    var errorMessage: Observable<String> { errorMessageRelay.asObservable() }
 }

--- a/SixthSense/Challenge/Sources/Check/ChallengeCheckInteractor.swift
+++ b/SixthSense/Challenge/Sources/Check/ChallengeCheckInteractor.swift
@@ -46,12 +46,16 @@ final class ChallengeCheckInteractor: PresentableInteractor<ChallengeCheckPresen
     weak var listener: ChallengeCheckListener?
     private let dependency: ChallengeCheckInteractorDependency
     
+    private let id: Int
+    
     private let doneButtonActiveRelay: PublishRelay<Bool> = .init()
     private let showDonePopUpRelay: PublishRelay<ChallengeCheckComplete> = .init()
 
     init(presenter: ChallengeCheckPresentable,
+         id: Int,
          dependency: ChallengeCheckInteractorDependency) {
         self.dependency = dependency
+        self.id = id
         super.init(presenter: presenter)
         presenter.handler = self
     }

--- a/SixthSense/Challenge/Sources/Check/ChallengeCheckViewController.swift
+++ b/SixthSense/Challenge/Sources/Check/ChallengeCheckViewController.swift
@@ -214,6 +214,13 @@ final class ChallengeCheckViewController: UIViewController, ChallengeCheckPresen
                 self?.showCompletePopUp($0)
             })
             .disposed(by: self.disposeBag)
+        
+        handler.errorMessage
+            .asDriver(onErrorJustReturn: .init())
+            .drive(onNext: { [weak self] in
+                self?.showToast($0, toastStyle: .error)
+            })
+            .disposed(by: self.disposeBag)
     }
 
     private func configureNavigationBar() {

--- a/SixthSense/Home/Sources/Challenge/ChallengeBuilder.swift
+++ b/SixthSense/Home/Sources/Challenge/ChallengeBuilder.swift
@@ -9,13 +9,19 @@
 import RIBs
 import RxRelay
 import Foundation
+import Repository
 
-protocol ChallengeDependency: Dependency { }
+protocol ChallengeDependency: Dependency {
+    var userChallengeRepository: UserChallengeRepository { get }
+}
 
 final class ChallengeComponent: Component<ChallengeDependency>,
                                 ChallengeCalendarDependency,
                                 ChallengeListDependency{
     var targetDate: PublishRelay<Date>
+    var userChallengeRepository: UserChallengeRepository {
+        dependency.userChallengeRepository
+    }
     
     override init(dependency: ChallengeDependency) {
         targetDate = .init()

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListBuilder.swift
@@ -10,16 +10,21 @@ import RIBs
 import RxRelay
 import Foundation
 import Challenge
+import Repository
 
 protocol ChallengeListDependency: Dependency {
     var targetDate: PublishRelay<Date> { get }
+    var userChallengeRepository: UserChallengeRepository { get }
 }
 
 final class ChallengeListComponent: Component<ChallengeListDependency>,
                                     ChallengeListInteractorDependency,
                                     ChallengeCheckDependency,
                                     ChallengeDetailDependency {
-    var usecase: ChallengeListUseCase { ChallengeListUseCaseImpl() }
+    var usecase: ChallengeListUseCase {
+        ChallengeListUseCaseImpl(
+            repository: dependency.userChallengeRepository)
+    }
     var targetDate: PublishRelay<Date> { dependency.targetDate }
 }
 

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -225,6 +225,8 @@ extension ChallengeSectionItem: RawRepresentable {
                 self = .failed(viewModel)
             case .waiting:
                 self = .waiting(viewModel)
+            case .none:
+                return nil
         }
     }
 }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -11,9 +11,10 @@ import RxSwift
 import RxRelay
 import Foundation
 import UIKit
+import Challenge
 
 protocol ChallengeListRouting: ViewableRouting {
-    func attachCheck()
+    func attachCheck(id: Int)
     func detachCheck()
     func attachDetail(id: String)
     func detachDetail()
@@ -166,7 +167,9 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
     private func waitingItemSelected(viewModel: ChallengeItemCellViewModel) {
         guard let type = dependency.usecase.compareToday(with: targetDate),
               type == .today else { return }
-        router?.attachCheck()
+        router?.attachCheck(id: viewModel.id)
+    }
+    
     }
     
     private func itemDelete(_ indexPath: IndexPath) {

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListRouter.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListRouter.swift
@@ -41,10 +41,10 @@ final class ChallengeListRouter: ViewableRouter<ChallengeListInteractable, Chall
         viewControllable.uiviewController.tabBarController?.selectedIndex = 1
     }
     
-    func attachCheck() {
+    func attachCheck(id: Int) {
         if childRouting != nil { return }
         
-        let router = checkBuilder.build(withListener: interactor)
+        let router = checkBuilder.build(withListener: interactor, id: id)
         let viewController = router.viewControllable
         viewController.uiviewController.modalPresentationStyle = .fullScreen
         viewController.uiviewController.hidesBottomBarWhenPushed = true

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import RxSwift
+import Repository
 
 protocol ChallengeListUseCase {
     func list(by date: Date) -> Observable<[ChallengeItem]>
@@ -15,7 +16,12 @@ protocol ChallengeListUseCase {
     func compareToday(with date: Date) -> DateType?
 }
 
-struct ChallengeListUseCaseImpl: ChallengeListUseCase {
+final class ChallengeListUseCaseImpl: ChallengeListUseCase {
+    private let repository: UserChallengeRepository
+    init(repository: UserChallengeRepository) {
+        self.repository = repository
+    }
+    
     func list(by date: Date) -> Observable<[ChallengeItem]> {
         // TODO: 테스트 코드 제거
         return .just([

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -59,13 +59,20 @@ struct ChallengeItem {
     let id: String
     let emoji: String
     let title: String
-    let status: ChallengeAchievedStatus
+    let status: ChallengeAchievedStatus?
+    
+    init(model: UserChallengeItem) {
+        self.id = model.id
+        self.emoji = model.emoji
+        self.title = model.name
+        self.status = .init(rawValue: model.verificationStatus)
+    }
 }
 
-enum ChallengeAchievedStatus {
-    case success
-    case failed
-    case waiting
+enum ChallengeAchievedStatus: String {
+    case success = "SUCCESS"
+    case failed = "FAILED"
+    case waiting = "WAITING"
 }
 
 enum DateType {

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -23,13 +23,14 @@ final class ChallengeListUseCaseImpl: ChallengeListUseCase {
     }
     
     func list(by date: Date) -> Observable<[ChallengeItem]> {
-        // TODO: 테스트 코드 제거
-        return .just([
-            .init(id: "아이디아이디1", emoji: "🦊", title: "하루 채식", status: .success),
-            .init(id: "아이디아이디2", emoji: "📆", title: "\(date)", status: .failed),
-            .init(id: "아이디아이디3", emoji: "🥬", title: "하루 채식", status: .success),
-            .init(id: "아이디아이디4", emoji: "🥵", title: "하루 채식", status: .waiting),
-        ])
+        return repository.dayList(by: date.toString(dateFormat: "yyyy-MM-dd"))
+            .asObservable()
+            .compactMap { UserChallengeList(JSONString: $0) }
+            .flatMap { response -> Observable<[ChallengeItem]> in
+                return .just(response.data.map {
+                    ChallengeItem(model: $0)
+                })
+            }
     }
     
     func delete(id: String) -> Observable<Void> {

--- a/SixthSense/Home/Sources/ChallengeList/Domain/UserChallengeList.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/UserChallengeList.swift
@@ -1,0 +1,57 @@
+//
+//  ChallengeList.swift
+//  Home
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import ObjectMapper
+
+struct UserChallengeList: Mappable {
+    var data: [UserChallengeItem]
+    
+    init() {
+        data = []
+    }
+    
+    init?(map: Map) {
+        self.init()
+    }
+    
+    mutating func mapping(map: Map) {
+        data <- map["data"]
+    }
+}
+
+struct UserChallengeItem: Mappable {
+    var id: String
+    var challengeID: String
+    var name: String
+    var emoji: String
+    var challengeDate: String
+    var verificationStatus: String
+    
+    init() {
+        id = ""
+        challengeID = ""
+        name = ""
+        emoji = ""
+        challengeDate = ""
+        verificationStatus = ""
+    }
+    
+    init?(map: Map) {
+        self.init()
+    }
+    
+    mutating func mapping(map: Map) {
+        id <- map["id"]
+        challengeID <- map["challengeID"]
+        name <- map["name"]
+        emoji <- map["emoji"]
+        challengeDate <- map["challengeDate"]
+        verificationStatus <- map["verificationStatus"]
+    }
+}

--- a/SixthSense/Home/Sources/Home/HomeComponent.swift
+++ b/SixthSense/Home/Sources/Home/HomeComponent.swift
@@ -16,6 +16,7 @@ final class HomeComponent: Component<HomeDependency>,
                             ChallengeRegisterDependency {
 
     var challengeRegisterUseCase: ChallengeRegisterUseCase
+    var userChallengeRepository: UserChallengeRepository
     var challengeRepository: ChallengeRepository
     var userRepository: UserRepository
     var myPageUseCase: MyPageUseCase
@@ -29,6 +30,9 @@ final class HomeComponent: Component<HomeDependency>,
         self.userRepository = dependency.userRepository
         self.myPageUseCase = MyPageUseCaseImpl(userRepository: dependency.userRepository)
         self.challengeRepository = dependency.challengeRepository
+        self.userChallengeRepository = UserChallengeRepositoryImpl(
+            network: dependency.network)
+        
         self.challengeRegisterUseCase = ChallengeRegisterUseCaseImpl(challengeRepository: dependency.challengeRepository)
         super.init(dependency: dependency)
     }

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeAPI.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeAPI.swift
@@ -1,0 +1,92 @@
+//
+//  UserChallengeAPI.swift
+//  Repository
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import Moya
+import Utils
+
+enum UserChallengeAPI {
+    case monthList(String)
+    case dayList(String)
+    case verify(ChallengeVerifyRequest)
+    case deleteVerify(Int)
+}
+
+extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
+
+    var baseURL: URL {
+        return API.EndPoint.base.url
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+            case .dayList, .monthList, .deleteVerify:
+                return ["Content-Type": "application/json"]
+            case .verify:
+                return ["Content-Type": "multipart/form-data"]
+        }
+    }
+
+    var path: String {
+        switch self {
+            case .monthList:
+                return "/user/challenge/month/list"
+            case .dayList:
+                return "/user/challenge/list"
+            case .verify, .deleteVerify:
+                return "/user/challenge/verify"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+            case .monthList, .dayList:
+                return .get
+            case .verify:
+                return .post
+            case .deleteVerify:
+                return .delete
+        }
+    }
+    
+    var authorizationType: AuthorizationType? {
+        return .bearer
+    }
+
+    var task: Task {
+        guard let parameters = parameters else { return .requestPlain }
+        switch self {
+            case .monthList, .dayList, .deleteVerify:
+                return .requestParameters(parameters: parameters, encoding: parameterEncoding)
+            case .verify(let request):
+                return .uploadMultipart(request.asMultipart)
+        }
+    }
+    
+    var parameters: [String: Any]? {
+        switch self {
+            case .monthList(let date):
+                return ["date": date]
+            case .dayList(let date):
+                return ["date": date]
+            case .verify:
+                return [:]
+            case .deleteVerify(let id):
+                return ["userChallengeId": id]
+        }
+    }
+
+    var parameterEncoding: ParameterEncoding {
+        switch self {
+            case .monthList, .dayList, .deleteVerify:
+                return URLEncoding.queryString
+            case .verify:
+                return JSONEncoding.default
+        }
+    }
+}

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepository.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepository.swift
@@ -1,0 +1,18 @@
+//
+//  UserChallengeRepository.swift
+//  Repository
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+public protocol UserChallengeRepository: AnyObject {
+    func monthList(by date: String) -> Single<String>
+    func dayList(by date: String) -> Single<String>
+    func verify(request: ChallengeVerifyRequest) -> Single<String>
+    func deleteVerify(id: Int) -> Single<String>
+}
+

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepositoryImpl.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepositoryImpl.swift
@@ -1,0 +1,51 @@
+//
+//  UserChallengeRepositoryImpl.swift
+//  Repository
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import RxSwift
+import Moya
+
+public final class UserChallengeRepositoryImpl: UserChallengeRepository {
+
+    private let network: Network
+
+    public init(network: Network) {
+        self.network = network
+    }
+    
+    public func monthList(by date: String) -> Single<String> {
+        return network.request(UserChallengeAPI.monthList(date))
+            .mapString()
+            .flatMap { data -> Single<String> in
+                return .just(data)
+            }
+    }
+    
+    public func dayList(by date: String) -> Single<String> {
+        return network.request(UserChallengeAPI.dayList(date))
+            .mapString()
+            .flatMap { data -> Single<String> in
+                return .just(data)
+            }
+    }
+    
+    public func verify(request: ChallengeVerifyRequest) -> Single<String> {
+        return network.request(UserChallengeAPI.verify(request))
+            .mapString()
+            .flatMap { data -> Single<String> in
+                return .just(data)
+            }
+    }
+    
+    public func deleteVerify(id: Int) -> Single<String> {
+        return network.request(UserChallengeAPI.deleteVerify(id))
+            .mapString()
+            .flatMap { data -> Single<String> in
+                return .just(data)
+            }
+    }
+}

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeRequest.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeRequest.swift
@@ -1,0 +1,33 @@
+//
+//  UserChallengeRequest.swift
+//  Repository
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Moya
+
+public struct ChallengeVerifyRequest {
+    var id: Int
+    var image: UIImage?
+    var text: String?
+    
+    public init(id: Int, image: UIImage?, text: String?) {
+        self.id = id
+        self.image = image
+        self.text = text
+    }
+}
+
+extension ChallengeVerifyRequest {
+    var asMultipart: [MultipartFormData] {
+        return [
+            .init(provider: .data(self.image!.jpegData(compressionQuality: 0.5)!), name: "images", fileName: "\(self.id).jpeg", mimeType: "image/jpeg"),
+            .init(provider: .data(String(self.id).data(using: .utf8)!), name: "userChallengeId"),
+            .init(provider: .data(String(self.text ?? " ").data(using: .utf8)!), name: "memo")
+        ]
+    }
+}


### PR DESCRIPTION
### 작업사항
- 인증등록 엔티티모델을 구성하고 UseCase를 구성했어요
- 요청 실패시 에러 토스트를 띄우는 로직을 구성했어요
- 인증등록에 사용될 Request모델을 Repository 모듈에 구성했어요

### 스크린샷
https://user-images.githubusercontent.com/69489688/189515039-df40da6a-6e32-45da-ad50-ba5391466be5.mov


