### PR TITLE
[App] 챌린지 리스트 fetch 로직을 개선하고 챌린지 추가 로직을 구현했어요

### DIFF
--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListBuilder.swift
@@ -11,19 +11,25 @@ import RxRelay
 import Foundation
 import Challenge
 import Repository
+import Storage
 
 protocol ChallengeListDependency: Dependency {
     var targetDate: PublishRelay<Date> { get }
     var userChallengeRepository: UserChallengeRepository { get }
+    var persistence: LocalPersistence { get }
 }
 
 final class ChallengeListComponent: Component<ChallengeListDependency>,
                                     ChallengeListInteractorDependency,
                                     ChallengeCheckDependency,
                                     ChallengeDetailDependency {
+    var userChallengeRepository: UserChallengeRepository { dependency.userChallengeRepository }
+    
     var usecase: ChallengeListUseCase {
         ChallengeListUseCaseImpl(
-            repository: dependency.userChallengeRepository)
+            repository: dependency.userChallengeRepository,
+            persistence: dependency.persistence
+        )
     }
     var targetDate: PublishRelay<Date> { dependency.targetDate }
 }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -25,6 +25,7 @@ protocol ChallengeListPresenterAction: AnyObject {
     var fetch: Observable<Void> { get }
     var itemSelected: Observable<IndexPath> { get }
     var itemDidDeleted: Observable<IndexPath> { get }
+    var registerDidTap: Observable<Void> { get }
 }
 
 protocol ChallengeListPresenterHandler: AnyObject {
@@ -103,6 +104,13 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
             })
             .disposeOnDeactivate(interactor: self)
         
+        action.registerDidTap
+            .withUnretained(self)
+            .subscribe(onNext: { owner, _ in
+                owner.addItemSelected()
+            })
+            .disposeOnDeactivate(interactor: self)
+        
         dependency.targetDate
             .withUnretained(self)
             .subscribe(onNext: { owner, date in
@@ -145,7 +153,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
             case .waiting(let viewModel):
                 waitingItemSelected(viewModel: viewModel)
             case .add:
-                router?.routeToRegister()
+                addItemSelected()
             case .failed, .spacing:
                 break
         }
@@ -166,6 +174,8 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
         router?.attachCheck(id: viewModel.id)
     }
     
+    private func addItemSelected() {
+        router?.routeToRegister()
     }
     
     private func itemDelete(_ indexPath: IndexPath) {
@@ -178,7 +188,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
         }
     }
     
-    private func deleteChallenge(id: String) {
+    private func deleteChallenge(id: Int) {
         dependency.usecase.delete(id: id)
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
@@ -10,7 +10,6 @@ import RIBs
 import RxSwift
 import RxRelay
 import UIKit
-import RxAppState
 import RxDataSources
 import SnapKit
 import Then
@@ -22,6 +21,7 @@ final class ChallengeListViewController: UIViewController, ChallengeListPresenta
     weak var handler: ChallengeListPresenterHandler?
     weak var action: ChallengeListPresenterAction?
     
+    private let fetchRelay: PublishRelay<Void> = .init()
     private let itemDeleteRelay: PublishRelay<IndexPath> = .init()
     
     private enum Constants { }
@@ -83,6 +83,11 @@ final class ChallengeListViewController: UIViewController, ChallengeListPresenta
         configureViews()
         configureConstraints()
         bind()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchRelay.accept(())
     }
     
     private func configureViews() {
@@ -195,7 +200,7 @@ extension ChallengeListViewController: UITableViewDelegate {
 
 
 extension ChallengeListViewController: ChallengeListPresenterAction {
-    var viewDidAppear: Observable<Void> { rx.viewDidAppear.asObservable().map { _ in () } }
+    var fetch: Observable<Void> { fetchRelay.asObservable() }
     var itemSelected: Observable<IndexPath> { tableView.rx.itemSelected
         .flatMap { index -> Observable<IndexPath> in .just(index)} }
     var itemDidDeleted: Observable<IndexPath> { itemDeleteRelay.asObservable() }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListViewController.swift
@@ -204,4 +204,5 @@ extension ChallengeListViewController: ChallengeListPresenterAction {
     var itemSelected: Observable<IndexPath> { tableView.rx.itemSelected
         .flatMap { index -> Observable<IndexPath> in .just(index)} }
     var itemDidDeleted: Observable<IndexPath> { itemDeleteRelay.asObservable() }
+    var registerDidTap: Observable<Void> { emptyView.rx.tap }
 }

--- a/SixthSense/Home/Sources/ChallengeList/Views/ChallengeAddCell.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Views/ChallengeAddCell.swift
@@ -69,7 +69,8 @@ class ChallengeAddCell: UITableViewCell {
         
         image.snp.makeConstraints {
             $0.right.equalTo(titleLabel.snp.left).offset(-10)
-            $0.left.top.bottom.equalToSuperview()
+            $0.left.centerY.equalToSuperview()
+            $0.size.equalTo(20)
         }
 
         titleLabel.snp.makeConstraints {

--- a/SixthSense/Home/Sources/ChallengeList/Views/ChallengeEmptyView.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Views/ChallengeEmptyView.swift
@@ -88,7 +88,5 @@ final class ChallengeEmptyView: UIView {
 }
 
 extension Reactive where Base: ChallengeEmptyView {
-    var tap: Observable<Void> {
-        base.button.rx.controlEvent(.editingDidBegin).map { _ in () }
-    }
+    var tap: Observable<Void> { base.button.rx.tap.map { _ in () } }
 }


### PR DESCRIPTION
### 작업사항
- 화면 진입 마다 리스트를 갱신하도록 변경했어요
- `emptyView` 내 챌린지 추가 버튼 인터렉션을 구현하였어요
- 챌린지 추가하기 아이콘 제약을 수정했어요

### 스크린샷
https://user-images.githubusercontent.com/69489688/189515244-982817b2-5f07-4d71-bcff-21bb32f9eb49.MP4

