### PR TITLE
[App] 홈 | 캘린더 ↔ 등록 간 기준일의 싱크를 맞추는 로직을 구성했어요

### DIFF
--- a/SixthSense/Home/Sources/Challenge/ChallengeBuilder.swift
+++ b/SixthSense/Home/Sources/Challenge/ChallengeBuilder.swift
@@ -10,23 +10,22 @@ import RIBs
 import RxRelay
 import Foundation
 import Repository
+import Storage
 
 protocol ChallengeDependency: Dependency {
     var userChallengeRepository: UserChallengeRepository { get }
+    var targetDate: PublishRelay<Date> { get }
+    var persistence: LocalPersistence { get }
 }
 
 final class ChallengeComponent: Component<ChallengeDependency>,
                                 ChallengeCalendarDependency,
                                 ChallengeListDependency{
-    var targetDate: PublishRelay<Date>
+    var targetDate: PublishRelay<Date> { dependency.targetDate }
     var userChallengeRepository: UserChallengeRepository {
         dependency.userChallengeRepository
     }
-    
-    override init(dependency: ChallengeDependency) {
-        targetDate = .init()
-        super.init(dependency: dependency)
-    }
+    var persistence: LocalPersistence { dependency.persistence }
 }
 
 // MARK: - Builder

--- a/SixthSense/Home/Sources/ChallengeCalendar/CalendarConfigure.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/CalendarConfigure.swift
@@ -55,6 +55,7 @@ struct CalendarConfiguration {
     mutating func setBasisDate(date: Date) {
         basisYear = date.toString(dateFormat: "yyyy")
         basisMonth = date.toString(dateFormat: "MM")
+        basisDay = date.toString(dateFormat: "dd")
     }
 }
 

--- a/SixthSense/Home/Sources/ChallengeRegister/RIB/ChallengeRegisterBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeRegister/RIB/ChallengeRegisterBuilder.swift
@@ -8,12 +8,15 @@
 
 import RIBs
 import Challenge
+import Foundation
+import RxRelay
 import Repository
 
 public protocol ChallengeRegisterDependency: Dependency {
     var network: Network { get }
     var challengeRepository: ChallengeRepository { get }
     var challengeRegisterUseCase: ChallengeRegisterUseCase { get }
+    var targetDate: PublishRelay<Date> { get }
 }
 
 public final class ChallengeRegisterComponent: Component<ChallengeRegisterDependency>,
@@ -22,6 +25,7 @@ public final class ChallengeRegisterComponent: Component<ChallengeRegisterDepend
     var useCase: ChallengeRegisterUseCase
     public var challengeRepository: ChallengeRepository { dependency.challengeRepository }
     public var network: Network { dependency.network }
+    public var targetDate: PublishRelay<Date> { dependency.targetDate }
 
     override init(dependency: ChallengeRegisterDependency) {
         self.useCase = ChallengeRegisterUseCaseImpl(challengeRepository: dependency.challengeRepository)

--- a/SixthSense/Home/Sources/Home/HomeBuilder.swift
+++ b/SixthSense/Home/Sources/Home/HomeBuilder.swift
@@ -9,11 +9,13 @@
 import RIBs
 import Challenge
 import Repository
+import Storage
 
 public protocol HomeDependency: Dependency {
     var network: Network { get }
     var challengeRepository: ChallengeRepository { get }
     var userRepository: UserRepository { get }
+    var persistence: LocalPersistence { get }
 }
 
 // MARK: - Builder

--- a/SixthSense/Home/Sources/Home/HomeComponent.swift
+++ b/SixthSense/Home/Sources/Home/HomeComponent.swift
@@ -8,7 +8,10 @@
 
 import RIBs
 import Challenge
+import RxRelay
+import Foundation
 import Repository
+import Storage
 
 final class HomeComponent: Component<HomeDependency>,
                             ChallengeDependency,
@@ -21,6 +24,8 @@ final class HomeComponent: Component<HomeDependency>,
     var userRepository: UserRepository
     var myPageUseCase: MyPageUseCase
     var network: Network
+    var targetDate: PublishRelay<Date>
+    var persistence: LocalPersistence { dependency.persistence }
     private let rootViewController: ViewControllable
 
     init(dependency: HomeDependency,
@@ -32,7 +37,7 @@ final class HomeComponent: Component<HomeDependency>,
         self.challengeRepository = dependency.challengeRepository
         self.userChallengeRepository = UserChallengeRepositoryImpl(
             network: dependency.network)
-        
+        self.targetDate = .init()
         self.challengeRegisterUseCase = ChallengeRegisterUseCaseImpl(challengeRepository: dependency.challengeRepository)
         super.init(dependency: dependency)
     }


### PR DESCRIPTION
### 작업사항
- `CalendarConfigure`내 기준일을 등록할때 일자도 등록하도록 변경했어요
- 챌린지 등록 targetDate를 갱신하는 로직을 추가했어요
- 챌린지 등록에서 불필요한 로직을 제거했어요
- `targetDate`를 `Home`에서 상태를 관리하도록 변경했어요

### 스크린샷
https://user-images.githubusercontent.com/69489688/189515350-38108b1d-c57e-4e87-a6c5-77240362dcfd.MP4

