### PR TITLE
[App] 캘린더 fetch 로직을 구현하고 달성률에 따라 캘린더 아이콘을 구성하는 로직을 구현했어요

### DIFF
--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarBuilder.swift
@@ -9,14 +9,23 @@
 import RIBs
 import RxRelay
 import Foundation
+import Repository
 
 protocol ChallengeCalendarDependency: Dependency {
     var targetDate: PublishRelay<Date> { get }
+    var userChallengeRepository: UserChallengeRepository { get }
 }
 
 final class ChallengeCalendarComponent: Component<ChallengeCalendarDependency>,
                                         ChallengeCalendarInteractorDependency{
+    var usecase: ChallengeCalendarUseCase
     var targetDate: PublishRelay<Date> { dependency.targetDate }
+    
+    override init(dependency: ChallengeCalendarDependency) {
+        self.usecase = ChallengeCalendarUsCaseImpl(
+            repository: dependency.userChallengeRepository)
+        super.init(dependency: dependency)
+    }
 }
 
 // MARK: - Builder

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarDayState.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarDayState.swift
@@ -9,9 +9,40 @@
 import Foundation
 
 enum ChallengeCalendarDayState: Int {
+    case none
     case zero
     case overZero
     case almost
     case done
     case waiting
+    
+    init?(percentage: Double, date: String) {
+        let calendar = Calendar.current
+        
+        if let today = Date().toString(dateFormat: "yyyy-MM-dd").toDate(dateFormat: "yyyy-MM-dd"),
+           let date = date.toDate(dateFormat: "yyyy-MM-dd"),
+           let interval = calendar.dateComponents([.year, .month, .day], from: today, to: date).day, interval >= 0 {
+            self.init(rawValue: 5)
+        }
+        
+        else if percentage == 0 {
+            self.init(rawValue: 1)
+        }
+
+        else if percentage == 1 {
+            self.init(rawValue: 4)
+        }
+
+        else if percentage > 0.5 {
+            self.init(rawValue: 3)
+        }
+
+        else if percentage > 0 {
+            self.init(rawValue: 2)
+        }
+        
+        else {
+            self.init(rawValue: 0)
+        }
+    }
 }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarInteractor.swift
@@ -30,6 +30,7 @@ protocol ChallengeCalendarPresenterHandler: AnyObject {
     var calenarDataSource: Observable<[[Int]]> { get }
     var calendar: (startDate: Date, endDate: Date) { get }
     var dayChallengeState: (Date) -> ChallengeCalendarDayState { get }
+    var reload: Observable<Void> { get }
 }
 
 protocol ChallengeCalendarPresentable: Presentable {
@@ -52,6 +53,7 @@ final class ChallengeCalendarInteractor: PresentableInteractor<ChallengeCalendar
     
     private let basisDateRelay: BehaviorRelay<Date> = .init(value: Date())
     private let calendarDataSourceRelay: PublishRelay<[[Int]]> = .init()
+    private let reloadRelay: PublishRelay<Void> = .init()
     
     // FIXME: 개발 후에 Factory로 분리할 계획이에요
     private var calendarConfiguration = CalendarConfiguration(startYear: 2022, endYear: 2026)
@@ -173,4 +175,5 @@ extension ChallengeCalendarInteractor: ChallengeCalendarPresenterHandler {
         return (startDate: calendarConfiguration.startDate, endDate: calendarConfiguration.endDate)
     }
     var dayChallengeState: (Date) -> ChallengeCalendarDayState { factory.dayChallengeState }
+    var reload: Observable<Void> { reloadRelay.asObservable() }
 }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarUseCase.swift
@@ -1,0 +1,61 @@
+//
+//  ChallengeCalendarUseCase.swift
+//  Home
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import Repository
+
+typealias DayState = ((Date) -> ChallengeCalendarDayState)
+
+protocol ChallengeCalendarUseCase {
+    func fetch(by date: Date) -> Observable<DayState>
+}
+
+final class ChallengeCalendarUsCaseImpl: ChallengeCalendarUseCase {
+    private let repository: UserChallengeRepository
+    
+    init(repository: UserChallengeRepository) {
+        self.repository = repository
+    }
+    
+    func fetch(by date: Date) -> Observable<DayState> {
+        return repository.monthList(by: date.toString(dateFormat: "yyyy-MM-dd"))
+            .asObservable()
+            .compactMap { UserChallengeCalendarList(JSONString: $0) }
+            .map(\.data)
+            .withUnretained(self)
+            .flatMap { owner, response -> Observable<DayState> in
+                owner.configureDayStates(response)
+            }
+    }
+    
+    private func configureDayStates(_ items: [UserChallengCalendarItem]) -> Observable<DayState> {
+        let challenges = items.compactMap { DayChallenge(date: $0.date,
+                                                         successCount: $0.successCount,
+                                                         totalCount: $0.totalCount)}
+
+        return .just { date in
+            challenges.filter {
+                $0.date == date.toString(dateFormat: "yyyy-MM-dd")
+            }
+            .compactMap(\.state)
+            .last ?? .none
+        }
+    }
+    
+    private struct DayChallenge {
+        let date: String
+        let state: ChallengeCalendarDayState?
+        
+        init?(date: String, successCount: Int, totalCount: Int) {
+            guard totalCount != 0 else { return nil }
+            self.date = date
+            self.state = ChallengeCalendarDayState(percentage: Double(successCount) / Double(totalCount), date: date)
+        }
+    }
+}

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController+Calendar.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController+Calendar.swift
@@ -55,7 +55,7 @@ struct DateState {
     var belongsToMonth: Bool { cellState.dateBelongsTo == .thisMonth }
     var title: String { cellState.text }
     var isToday: Bool { Calendar.current.isDateInToday(cellState.date) }
-    var challengeIcon: UIImage {
+    var challengeIcon: UIImage? {
         if isToday && challengeState == .waiting { return HomeAsset.challengeTodayWaiting.image}
         else { return challengeState.icon }
     }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController+Calendar.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController+Calendar.swift
@@ -18,15 +18,12 @@ extension ChallengeCalendarViewController: JTACMonthViewDataSource {
 }
 
 extension ChallengeCalendarViewController: JTACMonthViewDelegate {
-    func calendar(_ calendar: JTACMonthView, willDisplay cell: JTACDayCell, forItemAt date: Date, cellState: CellState, indexPath: IndexPath) {
-        guard let cell = calendar.dequeueReusableJTAppleCell(CalendarDayCell.self, for: indexPath) as? CalendarDayCell,
-              let challengeState = handler?.dayChallengeState(date) else { return }
-        cell.configure(state: .init(challengeState: challengeState, cellState: cellState))
-    }
+    func calendar(_ calendar: JTACMonthView, willDisplay cell: JTACDayCell, forItemAt date: Date, cellState: CellState, indexPath: IndexPath) { }
     
     func calendar(_ calendar: JTACMonthView, cellForItemAt date: Date, cellState: CellState, indexPath: IndexPath) -> JTACDayCell {
         guard let cell = calendar.dequeueReusableJTAppleCell(CalendarDayCell.self, for: indexPath) as? CalendarDayCell,
-              let challengeState = handler?.dayChallengeState(date) else { return .init() }
+              let challengeState = handler?.dayStates(date) else { return .init() }
+
         cell.configure(state: .init(challengeState: challengeState, cellState: cellState))
         return cell
     }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
@@ -192,6 +192,13 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
             })
             .disposed(by: self.disposeBag)
         
+        handler.reload
+            .asDriver(onErrorJustReturn: ())
+            .drive(onNext: { [weak self] in
+                self?.calendar.reloadData()
+            })
+            .disposed(by: self.disposeBag)
+        
         handler.calenarDataSource
             .bind(to: pickerView.rx.items(adapter: pickerAdapter))
             .disposed(by: self.disposeBag)

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
@@ -39,6 +39,7 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
     
     let swipeCalendarRelay: PublishRelay<Date> = .init()
     let dateSelectRelay: PublishRelay<Date> = .init()
+    private let fetchRelay: PublishRelay<Void> = .init()
     
     private let disposeBag = DisposeBag()
     private let pickerAdapter = RxPickerViewStringAdapter<[[Int]]>(
@@ -114,6 +115,11 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
         configureViews()
         configureConstraints()
         bind()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        fetchRelay.accept(())
     }
     
     private func configureViews() {
@@ -202,6 +208,7 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
 }
 
 extension ChallengeCalendarViewController: ChallengeCalendarPresenterAction {
+    var fetch: Observable<Void> { fetchRelay.asObservable() }
     var selectMonth: Observable<Void> { headerView.rx.tap }
     var monthBeginEditing: Observable<(row: Int, component: Int)> {
         pickerView.rx.itemSelected.asObservable()

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
@@ -179,7 +179,7 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
         handler.basisDate
             .asDriver(onErrorJustReturn: .init())
             .drive(onNext: { [weak self] in
-                self?.calendar.scrollToDate($0)
+                self?.calendar.scrollToDate($0, animateScroll: false)
             })
             .disposed(by: self.disposeBag)
         

--- a/SixthSense/Home/Sources/ChallengeCalendar/UserChallengeCalendarList.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/UserChallengeCalendarList.swift
@@ -1,0 +1,48 @@
+//
+//  ChallengeCalendarItem.swift
+//  Home
+//
+//  Created by 문효재 on 2022/09/09.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import ObjectMapper
+
+struct UserChallengeCalendarList: Mappable {
+    var data: [UserChallengCalendarItem]
+    
+    init() {
+        data = []
+    }
+    
+    init?(map: Map) {
+        self.init()
+    }
+    
+    mutating func mapping(map: Map) {
+        data <- map["data"]
+    }
+}
+
+struct UserChallengCalendarItem: Mappable {
+    var date: String
+    var successCount: Int
+    var totalCount: Int
+    
+    init() {
+        date = ""
+        successCount = 0
+        totalCount = 0
+    }
+    
+    init?(map: Map) {
+        self.init()
+    }
+    
+    mutating func mapping(map: Map) {
+        date <- map["date"]
+        successCount <- map["success_count"]
+        totalCount <- map["total_count"]
+    }
+}

--- a/SixthSense/Home/Sources/ChallengeCalendar/Views/CalendarDayCell.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/Views/CalendarDayCell.swift
@@ -122,8 +122,10 @@ final class CalendarDayCell: JTACDayCell {
 }
 
 extension ChallengeCalendarDayState {
-    var icon: UIImage {
+    var icon: UIImage? {
         switch self {
+            case .none:
+                return nil
             case .zero:
                 return HomeAsset.challengeDayZero.image
             case .overZero:


### PR DESCRIPTION
### 작업사항
- 캘린더 fetch 로직을 구성했어요
- 캘린더 reload하는 로직을 구현했어요 - fetch API 호출 이후 캘린더를 갱신하기 위함
- 챌린지 달성률에 따라 챌린지 캐릭터를 구성하는 로직을 추가했어요

### 스크린샷
https://user-images.githubusercontent.com/69489688/189515460-9808509f-3d71-42f0-9f2d-7d2a90524815.MP4

