### PR TITLE
[App] Root RIB UseCase 주입 로직을 개선하고 로그인 상태에 따라 첫화면을 다르게 보여주도록 구성했어요

### DIFF
--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInBuilder.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInBuilder.swift
@@ -8,19 +8,20 @@
 
 import RIBs
 import Repository
+import Storage
 
 public protocol SignInDependency: Dependency {
-    var network: Network { get }
-    var usecase: SignInUseCase { get }
     var userRepository: UserRepository { get }
+    var persistence: LocalPersistence { get }
 }
 
-final class SignInComponent: Component<SignInDependency>, SignUpDependency {
-    var useCase: SignUpUseCase
-    var network: Network { dependency.network }
+final class SignInComponent: Component<SignInDependency>, SignUpDependency, SignInInteractorDependency {
+    var usecase: SignInUseCase
+    var userRepository: UserRepository { dependency.userRepository }
 
     override init(dependency: SignInDependency) {
-        self.useCase = SignUpUseCaseImpl(userRepository: dependency.userRepository)
+        usecase = SignInUseCaseImpl(userRepository: dependency.userRepository,
+                                    persistence: dependency.persistence)
         super.init(dependency: dependency)
     }
 }
@@ -41,7 +42,7 @@ public final class SignInBuilder: Builder<SignInDependency>, SignInBuildable {
         let component = SignInComponent(dependency: dependency)
         let viewController = SignInViewController()
         let signUpBuilder = SignUpBuilder(dependency: component)
-        let interactor = SignInInteractor(presenter: viewController, dependency: dependency)
+        let interactor = SignInInteractor(presenter: viewController, dependency: component)
         interactor.listener = listener
         return SignInRouter(interactor: interactor,
                             viewController: viewController,

--- a/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
+++ b/SixthSense/Account/Sources/SignIn/Presentation/SignInInteractor.swift
@@ -24,13 +24,17 @@ public protocol SignInListener: AnyObject {
     func signInDidTapClose()
 }
 
+protocol SignInInteractorDependency {
+    var usecase: SignInUseCase { get }
+}
+
 final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInInteractable, SignInPresentableListener {
 
     weak var router: SignInRouting?
     weak var listener: SignInListener?
-    private let dependency: SignInDependency
+    private let dependency: SignInInteractorDependency
 
-    init(presenter: SignInPresentable, dependency: SignInDependency) {
+    init(presenter: SignInPresentable, dependency: SignInInteractorDependency) {
         self.dependency = dependency
         super.init(presenter: presenter)
         presenter.listener = self

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpBuilder.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpBuilder.swift
@@ -10,16 +10,14 @@ import RIBs
 import Repository
 
 public protocol SignUpDependency: Dependency {
-    var network: Network { get }
-    var useCase: SignUpUseCase { get }
+    var userRepository: UserRepository { get }
 }
 
-final class SignUpComponent: Component<SignUpDependency> {
-    var network: Network { dependency.network }
-    var payload: SignUpPayload
+final class SignUpComponent: Component<SignUpDependency>, SignUpInteractorDependency {
+    var useCase: SignUpUseCase
 
-    init(dependency: SignUpDependency, payload: SignUpPayload) {
-        self.payload = payload
+    override init(dependency: SignUpDependency) {
+        self.useCase = SignUpUseCaseImpl(userRepository: dependency.userRepository)
         super.init(dependency: dependency)
     }
 }
@@ -37,11 +35,11 @@ public final class SignUpBuilder: Builder<SignUpDependency>, SignUpBuildable {
     }
 
     public func build(withListener listener: SignUpListener, payload: SignUpPayload) -> SignUpRouting {
-        let component = SignUpComponent(dependency: dependency, payload: payload)
+        let component = SignUpComponent(dependency: dependency)
         let viewController = SignUpViewController()
         let interactor = SignUpInteractor(presenter: viewController,
-                                          dependency: dependency,
-                                          payload: component.payload)
+                                          dependency: component,
+                                          payload: payload)
         interactor.listener = listener
         return SignUpRouter(interactor: interactor, viewController: viewController)
     }

--- a/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
+++ b/SixthSense/Account/Sources/SignUp/Presentation/SignUpInteractor.swift
@@ -58,6 +58,10 @@ public protocol SignUpListener: AnyObject {
     func signUpComplete()
 }
 
+protocol SignUpInteractorDependency {
+    var useCase: SignUpUseCase { get }
+}
+
 final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpInteractable, SignUpPresentableListener {
 
     weak var router: SignUpRouting?
@@ -78,10 +82,10 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
 
     private var requests: SignUpRequest = .init()
     private let payload: SignUpPayload
-    private let dependency: SignUpDependency
+    private let dependency: SignUpInteractorDependency
 
     init(presenter: SignUpPresentable,
-         dependency: SignUpDependency,
+         dependency: SignUpInteractorDependency,
          payload: SignUpPayload) {
         self.dependency = dependency
         self.payload = payload

--- a/SixthSense/Splash/Sources/SplashRIB/SplashBuilder.swift
+++ b/SixthSense/Splash/Sources/SplashRIB/SplashBuilder.swift
@@ -14,12 +14,11 @@ import Home
 
 public protocol SplashDependency: Dependency {
     var network: Network { get }
-    var persistence: LocalPersistence { get }
     var userRepository: UserRepository { get }
     var challengeRepository: ChallengeRepository { get }
 }
 
-final class SplashComponent: Component<SplashDependency>, HomeDependency {
+final class SplashComponent: Component<SplashDependency> {
 
     var network: Network { dependency.network }
     var userRepository: UserRepository { dependency.userRepository }
@@ -43,17 +42,14 @@ public final class SplashBuilder: Builder<SplashDependency>, SplashBuildable {
     }
     
     public func build(withListener listener: SplashListener) -> SplashRouting {
-        let component = SplashComponent(dependency: dependency)
+        let _ = SplashComponent(dependency: dependency)
         let viewController = SplashViewController()
         let interactor = SplashInteractor(presenter: viewController)
-
-        let homeBuilder = HomeBuilder(dependency: component)
         
         interactor.listener = listener
         return SplashRouter(
             interactor: interactor,
-            viewController: viewController,
-            homeBuilder: homeBuilder
+            viewController: viewController
         )
     }
 }

--- a/SixthSense/Splash/Sources/SplashRIB/SplashRouter.swift
+++ b/SixthSense/Splash/Sources/SplashRIB/SplashRouter.swift
@@ -19,29 +19,12 @@ protocol SplashInteractable: Interactable, HomeListener {
 protocol SplashViewControllable: ViewControllable { }
 
 final class SplashRouter: ViewableRouter<SplashInteractable, SplashViewControllable>, SplashRouting {
-    private let homeBuilder: HomeBuildable
-    
     private var childRouting: ViewableRouting?
     
-    public init(
+    override public init(
         interactor: SplashInteractable,
-        viewController: SplashViewControllable,
-        homeBuilder: HomeBuildable
-    ) {
-        self.homeBuilder = homeBuilder
+        viewController: SplashViewControllable) {
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
-    }
-    
-    func attachHome() {
-        if childRouting != nil { return }
-        
-        let router = homeBuilder.build(withListener: interactor)
-        let viewController = router.viewControllable
-        viewController.uiviewController.modalPresentationStyle = .fullScreen
-        viewControllable.present(viewController, animated: false)
-        
-        attachChild(router)
-        self.childRouting = router
     }
 }

--- a/SixthSense/VegannerApp/Sources/Root/RootRIB/RootBuilder.swift
+++ b/SixthSense/VegannerApp/Sources/Root/RootRIB/RootBuilder.swift
@@ -35,7 +35,7 @@ final class RootBuilder: Builder<RootDependency>, RootBuildable {
     func build() -> LaunchRouting {
         let component = RootComponent(dependency: dependency)
         let viewController = RootViewController()
-        let interactor = RootInteractor(presenter: viewController)
+        let interactor = RootInteractor(presenter: viewController, dependency: component)
         
         let splashBuilder = SplashBuilder(dependency: component)
         let signInBuilder = SignInBuilder(dependency: component)

--- a/SixthSense/VegannerApp/Sources/Root/RootRIB/RootComponent.swift
+++ b/SixthSense/VegannerApp/Sources/Root/RootRIB/RootComponent.swift
@@ -21,12 +21,8 @@ final class RootComponent: Component<RootDependency>,
     var persistence: LocalPersistence { dependency.persistence }
     var userRepository: UserRepository { dependency.userRepository }
     var challengeRepository: ChallengeRepository { dependency.challengeRepository }
-    var usecase: SignInUseCase
     
     override init(dependency: RootDependency) {
-        self.usecase = SignInUseCaseImpl(
-            userRepository: dependency.userRepository,
-            persistence: dependency.persistence)
         
         super.init(dependency: dependency)
     }

--- a/SixthSense/VegannerApp/Sources/Root/RootRIB/RootComponent.swift
+++ b/SixthSense/VegannerApp/Sources/Root/RootRIB/RootComponent.swift
@@ -16,13 +16,17 @@ import Home
 final class RootComponent: Component<RootDependency>,
                            SplashDependency,
                            SignInDependency,
-                           HomeDependency {
+                           HomeDependency,
+                           RootInteractorDependency {
+    
     var network: Network { dependency.network }
     var persistence: LocalPersistence { dependency.persistence }
     var userRepository: UserRepository { dependency.userRepository }
     var challengeRepository: ChallengeRepository { dependency.challengeRepository }
+    var usecase: RootUseCase
     
     override init(dependency: RootDependency) {
+        self.usecase = RootUseCaseImpl(persistence: dependency.persistence)
         
         super.init(dependency: dependency)
     }

--- a/SixthSense/VegannerApp/Sources/Root/RootRIB/RootInteractor.swift
+++ b/SixthSense/VegannerApp/Sources/Root/RootRIB/RootInteractor.swift
@@ -22,6 +22,10 @@ public protocol RootPresentable: Presentable {
     var listener: RootPresentableListener? { get set }
 }
 
+protocol RootInteractorDependency {
+    var usecase: RootUseCase { get }
+}
+
 protocol RootListener: AnyObject {
 }
 
@@ -29,8 +33,10 @@ public final class RootInteractor: PresentableInteractor<RootPresentable>, RootI
 
     weak var router: RootRouting?
     weak var listener: RootListener?
+    private let dependency: RootInteractorDependency
 
-    public override init(presenter: RootPresentable) {
+    init(presenter: RootPresentable, dependency: RootInteractorDependency) {
+        self.dependency = dependency
         super.init(presenter: presenter)
         presenter.listener = self
     }
@@ -65,9 +71,8 @@ extension RootInteractor {
         }
     }
     
-    // FIXME: 아직 구현이 안된 메소드입니다
     private func shouldShowSignInView() -> Bool {
-        return true
+        return !dependency.usecase.logined()
     }
     
     public func signInDidTapClose() {

--- a/SixthSense/VegannerApp/Sources/Root/RootRIB/RootUseCase.swift
+++ b/SixthSense/VegannerApp/Sources/Root/RootRIB/RootUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  RootUseCase.swift
+//  VegannerApp
+//
+//  Created by 문효재 on 2022/09/10.
+//  Copyright © 2022 kr.co.thesixthsense. All rights reserved.
+//
+
+import Foundation
+import Storage
+
+protocol RootUseCase {
+    func logined() -> Bool
+}
+
+final class RootUseCaseImpl: RootUseCase {
+    private let persistence: LocalPersistence
+    
+    init(persistence: LocalPersistence) {
+        self.persistence = persistence
+    }
+    
+    func logined() -> Bool {
+        guard let token: String = persistence.value(on: .accessToken) else { return false }
+        return !token.isEmpty
+    }
+}


### PR DESCRIPTION
### 작업사항
- 기존에 UseCase를 최상위 RIB에서 주입하도록 구현되어있는데 UseCase와 RIB이 1:1 관계여서 바로 상위 RIB에서
주입하는게 메모리상 이점이 있다고 판단해서 변경했습니다. 단 Repository의 경우에는 최상위RIB에서 주입하도록 했어요
- 기존 Splash에 Home RIB에 의존되어있는데 불필요한 의존이어서 제거했어요
- `RootUseCase`를 구성하고 로그인 여부에 따라 엔트리포인트에서 분기처리되도록 변경했어요
