### PR TITLE
[App] 로그아웃, 회원탈퇴 라우팅 및 로직을 적용했어요

### DIFF
--- a/SixthSense/Challenge/Sources/ChallengeRecommend/Presentation/RIB/ChallengeRecommendBuilder.swift
+++ b/SixthSense/Challenge/Sources/ChallengeRecommend/Presentation/RIB/ChallengeRecommendBuilder.swift
@@ -10,7 +10,6 @@ import RIBs
 import Repository
 
 public protocol ChallengeRecommendDependency: Dependency {
-    var network: Network { get }
     var challengeRepository: ChallengeRepository { get }
 }
 

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
@@ -41,7 +41,7 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
     let dateSelectRelay: PublishRelay<Date> = .init()
     private let fetchRelay: PublishRelay<Void> = .init()
     
-    private let disposeBag = DisposeBag()
+    private var disposeBag = DisposeBag()
     private let pickerAdapter = RxPickerViewStringAdapter<[[Int]]>(
         components: [],
         numberOfComponents: { _,_,_  in 2 },
@@ -120,6 +120,11 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         fetchRelay.accept(())
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        disposeBag = DisposeBag()
     }
     
     private func configureViews() {

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarViewController.swift
@@ -34,6 +34,14 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
                     default: return .init()
                 }
             }
+            static let dateToYearMonth: (Date) -> String = {
+                let dateFormatter = DateFormatter().then {
+                    $0.dateFormat = "yyyy년 MM월"
+                    $0.timeZone = TimeZone(identifier: "KST")
+                }
+                
+                return dateFormatter.string(from: $0)
+            }
         }
     }
     
@@ -41,7 +49,7 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
     let dateSelectRelay: PublishRelay<Date> = .init()
     private let fetchRelay: PublishRelay<Void> = .init()
     
-    private var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
     private let pickerAdapter = RxPickerViewStringAdapter<[[Int]]>(
         components: [],
         numberOfComponents: { _,_,_  in 2 },
@@ -124,7 +132,6 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        disposeBag = DisposeBag()
     }
     
     private func configureViews() {
@@ -189,7 +196,7 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
             .disposed(by: self.disposeBag)
         
         handler.basisDate
-            .map(dateToYearMonthString)
+            .map(Constants.Picker.dateToYearMonth)
             .asDriver(onErrorJustReturn: .init())
             .drive(onNext: { [weak self] in
                 self?.headerView.monthLabel.text = $0
@@ -207,15 +214,6 @@ final class ChallengeCalendarViewController: UIViewController, ChallengeCalendar
         handler.calenarDataSource
             .bind(to: pickerView.rx.items(adapter: pickerAdapter))
             .disposed(by: self.disposeBag)
-    }
-    
-    private func dateToYearMonthString(_ date: Date) -> String {
-        let dateFormatter = DateFormatter().then {
-            $0.dateFormat = "yyyy년 MM월"
-            $0.timeZone = TimeZone(identifier: "KST")
-        }
-        
-        return dateFormatter.string(from: date)
     }
 }
 

--- a/SixthSense/Home/Sources/ChallengeRegister/Cell/ChallengeListItemCell.swift
+++ b/SixthSense/Home/Sources/ChallengeRegister/Cell/ChallengeListItemCell.swift
@@ -87,7 +87,6 @@ final class ChallengeListItemCell: UITableViewCell {
         contentLabel.font = AppFont.body2
     }
 
-    // FIXME: - Datasource
     func bind(item: ChallengeListItemCellViewModel) {
         contentLabel.setText(item.title, font: AppFont.body2)
         emojiLabel.text = item.emoji

--- a/SixthSense/Home/Sources/ChallengeRegister/RIB/ChallengeRegisterBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeRegister/RIB/ChallengeRegisterBuilder.swift
@@ -13,24 +13,15 @@ import RxRelay
 import Repository
 
 public protocol ChallengeRegisterDependency: Dependency {
-    var network: Network { get }
     var challengeRepository: ChallengeRepository { get }
-    var challengeRegisterUseCase: ChallengeRegisterUseCase { get }
     var targetDate: PublishRelay<Date> { get }
 }
 
 public final class ChallengeRegisterComponent: Component<ChallengeRegisterDependency>,
-    ChallengeRecommendDependency {
-
-    var useCase: ChallengeRegisterUseCase
+                                                 ChallengeRecommendDependency {
     public var challengeRepository: ChallengeRepository { dependency.challengeRepository }
-    public var network: Network { dependency.network }
     public var targetDate: PublishRelay<Date> { dependency.targetDate }
-
-    override init(dependency: ChallengeRegisterDependency) {
-        self.useCase = ChallengeRegisterUseCaseImpl(challengeRepository: dependency.challengeRepository)
-        super.init(dependency: dependency)
-    }
+    var useCase: ChallengeRegisterUseCase { ChallengeRegisterUseCaseImpl(challengeRepository: dependency.challengeRepository) }
 }
 
 // MARK: - Builder
@@ -49,7 +40,7 @@ public final class ChallengeRegisterBuilder: Builder<ChallengeRegisterDependency
         let component = ChallengeRegisterComponent(dependency: dependency)
         let viewController = ChallengeRegisterViewController()
         let interactor = ChallengeRegisterInteractor(presenter: viewController,
-                                                     dependency: dependency)
+                                                     dependency: component)
         interactor.listener = listener
 
         let recommendBuilder = ChallengeRecommendBuilder(dependency: component)

--- a/SixthSense/Home/Sources/ChallengeRegister/RIB/ChallengeRegisterViewController.swift
+++ b/SixthSense/Home/Sources/ChallengeRegister/RIB/ChallengeRegisterViewController.swift
@@ -174,6 +174,10 @@ final class ChallengeRegisterViewController: UIViewController, ChallengeRegister
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         configureUI()
         bind()
     }
@@ -181,6 +185,11 @@ final class ChallengeRegisterViewController: UIViewController, ChallengeRegister
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         configureLayout()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        disposeBag = DisposeBag()
     }
 
     func routeToHome() {
@@ -262,6 +271,7 @@ private extension ChallengeRegisterViewController {
         guard let handler = handler else { return }
 
         disposeBag.insert {
+
             handler.categorySections
                 .asDriver(onErrorJustReturn: [])
                 .drive(categoryTabView.rx.items(dataSource: categoryDataSource))
@@ -366,7 +376,6 @@ private extension ChallengeRegisterViewController {
 
 extension ChallengeRegisterViewController: ChallengeRegisterPresenterAction {
     var viewWillAppear: Observable<Void> { rx.viewWillAppear.map { _ in () }.asObservable() }
-    var viewWillDisappear: Observable<Void> { rx.viewWillDisappear.map { _ in () }.asObservable() }
     var didChangeCategory: Observable<(Int, CategorySectionItem)> {
         Observable.zip(categoryTabView.rx.itemSelected.map { $0.row }, categoryTabView.rx.modelSelected(CategorySectionItem.self))
             .distinctUntilChanged(\.0)

--- a/SixthSense/Home/Sources/Home/HomeInteractor.swift
+++ b/SixthSense/Home/Sources/Home/HomeInteractor.swift
@@ -10,6 +10,7 @@ import RIBs
 
 public protocol HomeRouting: ViewableRouting {
     func attachTabs()
+    func detachTabs()
 }
 
 protocol HomePresentable: Presentable {
@@ -17,6 +18,7 @@ protocol HomePresentable: Presentable {
 }
 
 public protocol HomeListener: AnyObject {
+    func routeToSignIn()
 }
 
 final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteractable, HomePresentableListener {
@@ -36,5 +38,10 @@ final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteract
 
     override func willResignActive() {
         super.willResignActive()
+        router?.detachTabs()
+    }
+
+    func routeToSignIn() {
+        listener?.routeToSignIn()
     }
 }

--- a/SixthSense/Home/Sources/Home/HomeRouter.swift
+++ b/SixthSense/Home/Sources/Home/HomeRouter.swift
@@ -25,7 +25,7 @@ protocol HomeViewControllable: ViewControllable {
 final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, HomeRouting {
     private let challengeHome: ChallengeBuildable
     private var challengeHomeRouting: ViewableRouting?
-    
+
     private let mypageHome: MyPageBuildable
     private var mypageHomeRouting: ViewableRouting?
 
@@ -37,29 +37,48 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, 
          challengeHome: ChallengeBuildable,
          challengeRegisterHome: ChallengeRegisterBuildable,
          mypageHome: MyPageBuildable) {
-        
+
         self.challengeHome = challengeHome
         self.mypageHome = mypageHome
         self.challengeRegisterHome = challengeRegisterHome
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
-    
+
     func attachTabs() {
         let challengeRouting = challengeHome.build(withListener: interactor)
         let challengeRegisterRouting = challengeRegisterHome.build(withListener: interactor)
         let mypageRouting = mypageHome.build(withListener: interactor)
-        
+
         attachChild(challengeRouting)
+        self.challengeHomeRouting = challengeRouting
         attachChild(challengeRegisterRouting)
+        self.challengeRegisterRouting = challengeRegisterRouting
         attachChild(mypageRouting)
-        
+        self.mypageHomeRouting = mypageRouting
+
         let viewControllers = [
             NavigationControllerable(root: challengeRouting.viewControllable),
             NavigationControllerable(root: challengeRegisterRouting.viewControllable),
             NavigationControllerable(root: mypageRouting.viewControllable)
         ]
-        
+
         viewController.setViewControllers(viewControllers)
+    }
+
+    func detachTabs() {
+        guard let challengeHomeRouting = challengeHomeRouting else { return }
+        guard let challengeRegisterRouting = challengeRegisterRouting else { return }
+        guard let mypageHomeRouting = mypageHomeRouting else { return }
+
+        detachChild(challengeHomeRouting)
+        detachChild(challengeRegisterRouting)
+        detachChild(mypageHomeRouting)
+
+        self.challengeHomeRouting = nil
+        self.challengeRegisterRouting = nil
+        self.mypageHomeRouting = nil
+
+        viewController.dismiss(animated: false, completion: nil)
     }
 }

--- a/SixthSense/Home/Sources/Home/RootTabBarController.swift
+++ b/SixthSense/Home/Sources/Home/RootTabBarController.swift
@@ -12,7 +12,7 @@ import RIBs
 protocol HomePresentableListener: AnyObject { }
 
 final class RootTabBarController: UITabBarController, HomeViewControllable, HomePresentable {
-    var listener: HomePresentableListener?
+    weak var listener: HomePresentableListener?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SixthSense/Home/Sources/MyPage/Domain/UseCases/MyPageUseCase.swift
+++ b/SixthSense/Home/Sources/MyPage/Domain/UseCases/MyPageUseCase.swift
@@ -8,20 +8,24 @@
 
 import Foundation
 import RxSwift
+import Storage
 import Repository
 
 public protocol MyPageUseCase {
     func fetchUserData() -> Observable<UserInfoModel>
     func fetchUserChallengeStats() -> Observable<UserChallengeStatModel>
     func logout() -> Observable<Void>
+    func isLoggedIn() -> Observable<Bool>
 
 }
 final class MyPageUseCaseImpl: MyPageUseCase {
 
     private let userRepository: UserRepository
+    private let persistence: LocalPersistence
 
-    init(userRepository: UserRepository) {
+    init(userRepository: UserRepository, persistence: LocalPersistence) {
         self.userRepository = userRepository
+        self.persistence = persistence
     }
 
     func fetchUserData() -> Observable<UserInfoModel> {
@@ -36,8 +40,14 @@ final class MyPageUseCaseImpl: MyPageUseCase {
             .asObservable()
     }
 
+    func isLoggedIn() -> Observable<Bool> {
+        guard let token: String = persistence.value(on: .accessToken) else { return .just(false) }
+        return .just(!token.isEmpty)
+    }
+
     func logout() -> Observable<Void> {
         return userRepository.logout()
+            .do(onSuccess: { [weak self] _ in self?.persistence.delete(on: .accessToken) })
             .flatMap({ _ in .just(()) })
             .asObservable()
     }

--- a/SixthSense/Home/Sources/MyPage/RIB/MyPageBuilder.swift
+++ b/SixthSense/Home/Sources/MyPage/RIB/MyPageBuilder.swift
@@ -7,15 +7,18 @@
 //
 
 import RIBs
+import Storage
 import Repository
 
 protocol MyPageDependency: Dependency {
     var userRepository: UserRepository { get }
+    var persistence: LocalPersistence { get }
 }
 
 final class MyPageComponent: Component<MyPageDependency>, MyPageModifyDependency, MyPageWebViewDependency {
     var userRepository: UserRepository { dependency.userRepository }
-    var myPageUseCase: MyPageUseCase { MyPageUseCaseImpl(userRepository: dependency.userRepository) }
+    var myPageUseCase: MyPageUseCase { MyPageUseCaseImpl(userRepository: dependency.userRepository,
+                                                         persistence: dependency.persistence) }
 }
 
 // MARK: - Builder

--- a/SixthSense/Home/Sources/MyPage/RIB/MyPageViewController.swift
+++ b/SixthSense/Home/Sources/MyPage/RIB/MyPageViewController.swift
@@ -118,19 +118,23 @@ extension MyPageViewController {
             handler.presentLogoutPopup
                 .withUnretained(self)
                 .bind(onNext: { owner, _ in
-                owner.showAlert(title: "비거너를 로그아웃 할거야?",
-                                message: "남겨둔 챌린지와 인증글은 잘 보관되어 있으니\n잠시 쉬다가 와도 걱정하지 말아요😊",
-                                actions: [.action(title: "앗.. 아냐!", style: .negative),
-                                              .action(title: "응, 로그아웃 할게", style: .positive)])
-                    .filter { $0 == .positive }
-                    .bind(onNext: { _ in owner.logout() })
-                    .disposed(by: owner.disposeBag)
+                owner.presentLogout()
             })
         }
     }
 
     private func logout() {
         logoutButtonTapped.accept(true)
+    }
+
+    private func presentLogout() {
+        showAlert(title: "비거너를 로그아웃 할거야?",
+                  message: "남겨둔 챌린지와 인증글은 잘 보관되어 있으니\n잠시 쉬다가 와도 걱정하지 말아요😊",
+                  actions: [.action(title: "앗.. 아냐!", style: .negative),
+                                .action(title: "응, 로그아웃 할게", style: .positive)])
+            .filter { $0 == .positive }
+            .bind(onNext: { [weak self] _ in self?.logout() })
+            .disposed(by: disposeBag)
     }
 }
 extension MyPageViewController: MyPagePresenterAction {

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
@@ -33,7 +33,7 @@ protocol MyPageModifyPresenterAction: AnyObject {
 
 protocol MyPageModifyListener: AnyObject {
     func popModifyView()
-//    func routeToSingIn()
+    func routeToSingIn()
 }
 
 final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentable>, MyPageModifyInteractable {
@@ -73,7 +73,7 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
         action.viewWillAppear
             .withUnretained(self)
             .bind(onNext: { owner, _ in
-            owner.userInfoPayloadRelay.accept(self.userInfo)
+            owner.userInfoPayloadRelay.accept(owner.userInfo)
         }).disposeOnDeactivate(interactor: self)
 
         action.didTapBackButton
@@ -100,12 +100,12 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
     }
 
     func withDrawUser() {
-//        useCase.withdrawUser()
-//            .withUnretained(self)
-//            .bind(onNext: { owner, _ in
-//            owner.popModifyInfoView()
-//            owner.listener?.routeToSingIn()
-//        }).disposeOnDeactivate(interactor: self)
+        useCase.withdrawUser()
+            .withUnretained(self)
+            .bind(onNext: { owner, _ in
+            owner.popModifyInfoView()
+            owner.listener?.routeToSingIn()
+        }).disposeOnDeactivate(interactor: self)
     }
 }
 

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
@@ -33,7 +33,7 @@ protocol MyPageModifyPresenterAction: AnyObject {
 
 protocol MyPageModifyListener: AnyObject {
     func popModifyView()
-    func routeToSingIn()
+    func routeToSignIn()
 }
 
 final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentable>, MyPageModifyInteractable {
@@ -91,7 +91,7 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
         action.withDrawConfirmed
             .withUnretained(self)
             .bind(onNext: { owner, _ in
-            owner.withDrawUser()
+            owner.withdrawUser()
         }).disposeOnDeactivate(interactor: self)
     }
 
@@ -99,12 +99,12 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
         router?.detachModifyInfoView()
     }
 
-    func withDrawUser() {
+    func withdrawUser() {
         useCase.withdrawUser()
             .withUnretained(self)
             .bind(onNext: { owner, _ in
             owner.popModifyInfoView()
-            owner.listener?.routeToSingIn()
+            owner.listener?.routeToSignIn()
         }).disposeOnDeactivate(interactor: self)
     }
 }

--- a/SixthSense/Splash/Sources/SplashRIB/SplashRouter.swift
+++ b/SixthSense/Splash/Sources/SplashRIB/SplashRouter.swift
@@ -11,7 +11,7 @@ import UIKit
 import Account
 import Home
 
-protocol SplashInteractable: Interactable, HomeListener {
+protocol SplashInteractable: Interactable {
     var router: SplashRouting? { get set }
     var listener: SplashListener? { get set }
 }
@@ -19,7 +19,6 @@ protocol SplashInteractable: Interactable, HomeListener {
 protocol SplashViewControllable: ViewControllable { }
 
 final class SplashRouter: ViewableRouter<SplashInteractable, SplashViewControllable>, SplashRouting {
-    private var childRouting: ViewableRouting?
     
     override public init(
         interactor: SplashInteractable,

--- a/SixthSense/VegannerApp/Sources/Root/RootRIB/RootInteractor.swift
+++ b/SixthSense/VegannerApp/Sources/Root/RootRIB/RootInteractor.swift
@@ -43,7 +43,7 @@ public final class RootInteractor: PresentableInteractor<RootPresentable>, RootI
 
     public override func didBecomeActive() {
         super.didBecomeActive()
-        
+
         // TODO: 스플래시 테스트를 위한 딜레이입니다 추후 제거
         Observable<Void>.just(())
             .delay(.seconds(3), scheduler: MainScheduler.instance)
@@ -63,20 +63,25 @@ public final class RootInteractor: PresentableInteractor<RootPresentable>, RootI
 extension RootInteractor {
     private func attachSignInIfNeeded() {
         router?.detachSplash()
-        
+
         if shouldShowSignInView() {
             router?.attachSignIn()
         } else {
             router?.attachHome()
         }
     }
-    
+
     private func shouldShowSignInView() -> Bool {
         return !dependency.usecase.logined()
     }
-    
+
     public func signInDidTapClose() {
         router?.detachSignIn()
         router?.attachHome()
+    }
+
+    public func routeToSignIn() {
+        router?.detachSplash()
+        router?.attachSignIn()
     }
 }


### PR DESCRIPTION
- Resolved #139  
---

### 설명
> 로그아웃, 회원탈퇴 라우팅 및 로직을 적용하고, 비회원인 경우 로그인 유도 팝업을 띄웠어요.


### 작업사항
- [x] : 마이페이지 - 홈 - 루트 - 로그인 라우팅 연결
- [x] : memeroy leak 되는 부분 수정
- [x] : 챌린지등록 usecase 주입 변경
- [x] : 마이페이지에 LocalPersistence 주입
- [x] : 마이페이지 - 비회원 팝업 추가
- [x] : 로그아웃, 회원탈퇴, 비로그인 유저- 로그인화면으로 라우팅 적용
- [x] : 로그아웃시 Access Token 삭제

### 스크린샷
> 로그아웃

https://user-images.githubusercontent.com/62925639/189523831-a951f0ee-d231-4dd0-8d68-14a4bfc97829.MP4

> 회원탈퇴

https://user-images.githubusercontent.com/62925639/189523875-72acd797-b7af-4590-81a2-715b98827e29.MP4

> 비회원 마이페이지 진입시 팝업

https://user-images.githubusercontent.com/62925639/189523931-701d3f4b-239e-479a-b049-0b4ad6b57f53.MP4

