### PR TITLE
[App] 리스트 | 리스트에 로그인 분기로직을 추가하고 챌린지 삭제 API를 연동했어요

### DIFF
--- a/SixthSense/Home/Sources/Challenge/ChallengeInteractor.swift
+++ b/SixthSense/Home/Sources/Challenge/ChallengeInteractor.swift
@@ -18,7 +18,9 @@ protocol ChallengePresentable: Presentable {
     var listener: ChallengePresentableListener? { get set }
 }
 
-protocol ChallengeListener: AnyObject { }
+protocol ChallengeListener: AnyObject {
+    func routeToSignIn()
+}
 
 final class ChallengeInteractor: PresentableInteractor<ChallengePresentable>, ChallengeInteractable, ChallengePresentableListener {
 
@@ -38,5 +40,9 @@ final class ChallengeInteractor: PresentableInteractor<ChallengePresentable>, Ch
 
     override func willResignActive() {
         super.willResignActive()
+    }
+    
+    func routeToSignIn() {
+        listener?.routeToSignIn()
     }
 }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarBuilder.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarBuilder.swift
@@ -10,10 +10,12 @@ import RIBs
 import RxRelay
 import Foundation
 import Repository
+import Storage
 
 protocol ChallengeCalendarDependency: Dependency {
     var targetDate: PublishRelay<Date> { get }
     var userChallengeRepository: UserChallengeRepository { get }
+    var persistence: LocalPersistence { get }
 }
 
 final class ChallengeCalendarComponent: Component<ChallengeCalendarDependency>,
@@ -23,7 +25,8 @@ final class ChallengeCalendarComponent: Component<ChallengeCalendarDependency>,
     
     override init(dependency: ChallengeCalendarDependency) {
         self.usecase = ChallengeCalendarUsCaseImpl(
-            repository: dependency.userChallengeRepository)
+            repository: dependency.userChallengeRepository,
+            persistence: dependency.persistence)
         super.init(dependency: dependency)
     }
 }

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarUseCase.swift
@@ -9,6 +9,7 @@
 import Foundation
 import RxSwift
 import Repository
+import Storage
 
 typealias DayState = ((Date) -> ChallengeCalendarDayState)
 
@@ -18,9 +19,13 @@ protocol ChallengeCalendarUseCase {
 
 final class ChallengeCalendarUsCaseImpl: ChallengeCalendarUseCase {
     private let repository: UserChallengeRepository
+    private let persistence: LocalPersistence
     
-    init(repository: UserChallengeRepository) {
+    init(repository: UserChallengeRepository,
+         persistence: LocalPersistence) {
         self.repository = repository
+        self.persistence = persistence
+    }
     }
     
     func fetch(by date: Date) -> Observable<DayState> {

--- a/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeCalendar/ChallengeCalendarUseCase.swift
@@ -26,9 +26,14 @@ final class ChallengeCalendarUsCaseImpl: ChallengeCalendarUseCase {
         self.repository = repository
         self.persistence = persistence
     }
+    
+    private func logined() -> Bool {
+        guard let token: String = persistence.value(on: .accessToken) else { return false }
+        return !token.isEmpty
     }
     
     func fetch(by date: Date) -> Observable<DayState> {
+        guard logined() else { return .empty() }
         return repository.monthList(by: date.toString(dateFormat: "yyyy-MM-dd"))
             .asObservable()
             .compactMap { UserChallengeCalendarList(JSONString: $0) }

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -40,6 +40,7 @@ protocol ChallengeListPresentable: Presentable {
 }
 
 protocol ChallengeListListener: AnyObject {
+    func routeToSignIn()
 }
 
 protocol ChallengeListInteractorDependency {
@@ -175,7 +176,11 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
     }
     
     private func addItemSelected() {
-        router?.routeToRegister()
+        if dependency.usecase.logined() {
+            router?.routeToRegister()
+        } else {
+            listener?.routeToSignIn()
+        }
     }
     
     private func itemDelete(_ indexPath: IndexPath) {

--- a/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
+++ b/SixthSense/Home/Sources/ChallengeList/ChallengeListInteractor.swift
@@ -64,7 +64,7 @@ final class ChallengeListInteractor: PresentableInteractor<ChallengeListPresenta
     private var targetDate: Date = .init()
     
     private let sectionsRelay: PublishRelay<[ChallengeSection]> = .init()
-    private let hasItemRelay: PublishRelay<Bool> = .init()
+    private let hasItemRelay: BehaviorRelay<Bool> = .init(value: false)
     private let showToastRelay: PublishRelay<String> = .init()
     
     init(presenter: ChallengeListPresentable, dependency: ChallengeListInteractorDependency) {

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -40,7 +40,7 @@ final class ChallengeListUseCaseImpl: ChallengeListUseCase {
     }
     
     func delete(id: Int) -> Observable<Void> {
-        return repository.deleteVerify(id: id)
+        return repository.deleteChallenge(id: id)
             .asObservable()
             .flatMap { _ -> Observable<Void> in
                 return .just(())

--- a/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
+++ b/SixthSense/Home/Sources/ChallengeList/Domain/ChallengeListUseCase.swift
@@ -28,6 +28,7 @@ final class ChallengeListUseCaseImpl: ChallengeListUseCase {
     }
     
     func list(by date: Date) -> Observable<[ChallengeItem]> {
+        guard logined() else { return .empty() }
         return repository.dayList(by: date.toString(dateFormat: "yyyy-MM-dd"))
             .asObservable()
             .compactMap { UserChallengeList(JSONString: $0) }

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeAPI.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeAPI.swift
@@ -85,12 +85,12 @@ extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
                 return ["userChallengeId": id]
         }
     }
-
+    
     var parameterEncoding: ParameterEncoding {
         switch self {
-            case .monthList, .dayList, .deleteVerify, .deleteChallenge:
+            case .monthList, .dayList, .deleteVerify:
                 return URLEncoding.queryString
-            case .verify:
+            case .verify, .deleteChallenge:
                 return JSONEncoding.default
         }
     }

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeAPI.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeAPI.swift
@@ -15,6 +15,7 @@ enum UserChallengeAPI {
     case dayList(String)
     case verify(ChallengeVerifyRequest)
     case deleteVerify(Int)
+    case deleteChallenge(Int)
 }
 
 extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
@@ -25,7 +26,7 @@ extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
     
     var headers: [String : String]? {
         switch self {
-            case .dayList, .monthList, .deleteVerify:
+            case .dayList, .monthList, .deleteVerify, .deleteChallenge:
                 return ["Content-Type": "application/json"]
             case .verify:
                 return ["Content-Type": "multipart/form-data"]
@@ -40,6 +41,8 @@ extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
                 return "/user/challenge/list"
             case .verify, .deleteVerify:
                 return "/user/challenge/verify"
+            case .deleteChallenge:
+                return "/user/challenge"
         }
     }
 
@@ -49,7 +52,7 @@ extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
                 return .get
             case .verify:
                 return .post
-            case .deleteVerify:
+            case .deleteVerify, .deleteChallenge:
                 return .delete
         }
     }
@@ -61,7 +64,7 @@ extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
     var task: Task {
         guard let parameters = parameters else { return .requestPlain }
         switch self {
-            case .monthList, .dayList, .deleteVerify:
+            case .monthList, .dayList, .deleteVerify, .deleteChallenge:
                 return .requestParameters(parameters: parameters, encoding: parameterEncoding)
             case .verify(let request):
                 return .uploadMultipart(request.asMultipart)
@@ -78,12 +81,14 @@ extension UserChallengeAPI: BaseAPI, AccessTokenAuthorizable {
                 return [:]
             case .deleteVerify(let id):
                 return ["userChallengeId": id]
+            case .deleteChallenge(let id):
+                return ["userChallengeId": id]
         }
     }
 
     var parameterEncoding: ParameterEncoding {
         switch self {
-            case .monthList, .dayList, .deleteVerify:
+            case .monthList, .dayList, .deleteVerify, .deleteChallenge:
                 return URLEncoding.queryString
             case .verify:
                 return JSONEncoding.default

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepository.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepository.swift
@@ -14,5 +14,6 @@ public protocol UserChallengeRepository: AnyObject {
     func dayList(by date: String) -> Single<String>
     func verify(request: ChallengeVerifyRequest) -> Single<String>
     func deleteVerify(id: Int) -> Single<String>
+    func deleteChallenge(id: Int) -> Single<String>
 }
 

--- a/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepositoryImpl.swift
+++ b/SixthSense/Repository/Sources/UserChallenge/UserChallengeRepositoryImpl.swift
@@ -48,4 +48,12 @@ public final class UserChallengeRepositoryImpl: UserChallengeRepository {
                 return .just(data)
             }
     }
+    
+    public func deleteChallenge(id: Int) -> Single<String> {
+        return network.request(UserChallengeAPI.deleteChallenge(id))
+            .mapString()
+            .flatMap { data -> Single<String> in
+                return .just(data)
+            }
+    }
 }


### PR DESCRIPTION
### 작업사항
- 캘린더와 리스트 화면에 로그인 분기로직을 추가했어요
- 사용자 챌린지 리스트 제거 API를 붙혔어요

### 스크린샷
https://user-images.githubusercontent.com/69489688/190424269-7aff0a36-01a3-44c4-b690-c22205e9968f.MP4


