### PR TITLE
[App] 회원정보수정 API 응답을 토스트로 반영했어요

### DIFF
--- a/SixthSense/Home/Sources/MyPage/RIB/MyPageBuilder.swift
+++ b/SixthSense/Home/Sources/MyPage/RIB/MyPageBuilder.swift
@@ -19,6 +19,12 @@ final class MyPageComponent: Component<MyPageDependency>, MyPageModifyDependency
     var userRepository: UserRepository { dependency.userRepository }
     var myPageUseCase: MyPageUseCase { MyPageUseCaseImpl(userRepository: dependency.userRepository,
                                                          persistence: dependency.persistence) }
+    var userInfoPayload: UserInfoPayload
+
+    override init(dependency: MyPageDependency) {
+        self.userInfoPayload = UserInfoPayload.init()
+        super.init(dependency: dependency)
+    }
 }
 
 // MARK: - Builder
@@ -36,7 +42,7 @@ final class MyPageBuilder: Builder<MyPageDependency>, MyPageBuildable {
     func build(withListener listener: MyPageListener) -> MyPageRouting {
         let component = MyPageComponent(dependency: dependency)
         let viewController = MyPageViewController()
-        let interactor = MyPageInteractor(presenter: viewController, useCase: component.myPageUseCase)
+        let interactor = MyPageInteractor(presenter: viewController, component: component)
         interactor.listener = listener
 
         let myPageWebViewBuilder = MyPageWebViewBuilder(dependency: component)

--- a/SixthSense/Home/Sources/MyPage/RIB/MyPageRouter.swift
+++ b/SixthSense/Home/Sources/MyPage/RIB/MyPageRouter.swift
@@ -50,14 +50,15 @@ final class MyPageRouter: ViewableRouter<MyPageInteractable, MyPageViewControlla
         self.childRouting = nil
     }
 
-    func routeToModifyView(userData: UserInfoPayload) {
+    func routeToModifyView() {
         if childRouting != nil { return }
 
-        let router = mypageModifyView.build(withListener: interactor, userData: userData)
+        let router = mypageModifyView.build(withListener: interactor)
         viewControllable.pushViewController(router.viewControllable, animated: true)
         self.childRouting = router
         attachChild(router)
     }
+
 
     func detachModifyView() {
         guard let router = childRouting else { return }

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyBuilder.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyBuilder.swift
@@ -11,17 +11,24 @@ import Repository
 
 protocol MyPageModifyDependency: Dependency {
     var userRepository: UserRepository { get }
+    var userInfoPayload: UserInfoPayload { get }
 }
 
 final class MyPageModifyComponent: Component<MyPageModifyDependency>, MyPageModifyInfoDependency {
     var userRepository: UserRepository { dependency.userRepository }
     var useCase: MyPageModifyUseCase { MyPageModifyUseCaseImpl(userRepository: dependency.userRepository) }
+    var userInfoPayload: UserInfoPayload
+
+    override init(dependency: MyPageModifyDependency) {
+        self.userInfoPayload = dependency.userInfoPayload
+        super.init(dependency: dependency)
+    }
 }
 
 // MARK: - Builder
 
 protocol MyPageModifyBuildable: Buildable {
-    func build(withListener listener: MyPageModifyListener, userData: UserInfoPayload) -> MyPageModifyRouting
+    func build(withListener listener: MyPageModifyListener) -> MyPageModifyRouting
 }
 
 final class MyPageModifyBuilder: Builder<MyPageModifyDependency>, MyPageModifyBuildable {
@@ -30,10 +37,10 @@ final class MyPageModifyBuilder: Builder<MyPageModifyDependency>, MyPageModifyBu
         super.init(dependency: dependency)
     }
 
-    func build(withListener listener: MyPageModifyListener, userData: UserInfoPayload) -> MyPageModifyRouting {
+    func build(withListener listener: MyPageModifyListener) -> MyPageModifyRouting {
         let component = MyPageModifyComponent(dependency: dependency)
         let viewController = MyPageModifyViewController()
-        let interactor = MyPageModifyInteractor(presenter: viewController, userPayload: userData, useCase: component.useCase)
+        let interactor = MyPageModifyInteractor(presenter: viewController, component: component)
         interactor.listener = listener
 
         let infoBuilder = MyPageModifyInfoBuilder(dependency: component)

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
@@ -22,6 +22,7 @@ protocol MyPageModifyPresentable: Presentable {
 
 protocol MyPageModifyPresenterHandler: AnyObject {
     var userInfoPayload: Observable<UserInfoPayload> { get }
+    var showToast: Observable<String> { get }
 }
 
 protocol MyPageModifyPresenterAction: AnyObject {
@@ -45,6 +46,7 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
 
     private let userInfoPayloadRelay: PublishRelay<UserInfoPayload> = .init()
     private let withDrawPopupRelay: PublishRelay<Void> = .init()
+    private let toastRelay: PublishRelay<String> = .init()
 
     private var disposeBag = DisposeBag()
 
@@ -92,8 +94,11 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
         }).disposeOnDeactivate(interactor: self)
     }
 
-    func popModifyInfoView(userInfo: UserInfoPayload) {
-        component.userInfoPayload = userInfo
+    func popModifyInfoView(userInfo: UserInfoPayload?) {
+        if let userInfo = userInfo {
+            component.userInfoPayload = userInfo
+            toastRelay.accept("정보 수정이 완료되었어요!")
+        }
         router?.detachModifyInfoView()
     }
 
@@ -101,7 +106,7 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
         component.useCase.withdrawUser()
             .withUnretained(self)
             .bind(onNext: { owner, _ in
-            owner.popModifyInfoView(userInfo: owner.component.userInfoPayload)
+            owner.popModifyInfoView(userInfo: nil)
             owner.listener?.routeToSignIn()
         }).disposeOnDeactivate(interactor: self)
     }
@@ -109,5 +114,6 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
 
 extension MyPageModifyInteractor: MyPageModifyPresenterHandler {
     var userInfoPayload: Observable<UserInfoPayload> { userInfoPayloadRelay.asObservable() }
+    var showToast: Observable<String> { toastRelay.asObservable() }
 }
 

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyInteractor.swift
@@ -41,7 +41,6 @@ final class MyPageModifyInteractor: PresentableInteractor<MyPageModifyPresentabl
     weak var router: MyPageModifyRouting?
     weak var listener: MyPageModifyListener?
 
-//    private let userInfo: UserInfoPayload
     private let component: MyPageModifyComponent
 
     private let userInfoPayloadRelay: PublishRelay<UserInfoPayload> = .init()

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyRouter.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyRouter.swift
@@ -13,8 +13,7 @@ protocol MyPageModifyInteractable: Interactable, MyPageModifyInfoListener {
     var listener: MyPageModifyListener? { get set }
 }
 
-protocol MyPageModifyViewControllable: ViewControllable {
-}
+protocol MyPageModifyViewControllable: ViewControllable { }
 
 final class MyPageModifyRouter: ViewableRouter<MyPageModifyInteractable, MyPageModifyViewControllable>, MyPageModifyRouting {
 
@@ -30,12 +29,11 @@ final class MyPageModifyRouter: ViewableRouter<MyPageModifyInteractable, MyPageM
         interactor.router = self
     }
 
-    func routeToModifyInfo(type: ModifyType, userInfoPayload: UserInfoPayload) {
+    func routeToModifyInfo(type: ModifyType) {
         if childRouting != nil { return }
 
         let router = modifyInfoBuilder.build(withListener: interactor,
-                                             type: type,
-                                             userInfoPayload: userInfoPayload)
+                                             type: type)
         viewControllable.pushViewController(router.viewControllable, animated: true)
         self.childRouting = router
         attachChild(router)

--- a/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyViewController.swift
+++ b/SixthSense/Home/Sources/MyPageModify/RIB/MyPageModifyViewController.swift
@@ -14,6 +14,7 @@ import RxCocoa
 import UIKit
 import RxAppState
 import DesignSystem
+import UICore
 
 final class MyPageModifyViewController: UIViewController, MyPageModifyPresentable, MyPageModifyViewControllable {
 
@@ -181,6 +182,11 @@ extension MyPageModifyViewController {
                 .map(\.vegannerStage.localized)
                 .bind(to: veganStageSubView.userDataLabel.rx.text)
 
+            handler.showToast
+                .withUnretained(self)
+                .bind(onNext: { owner, message in
+                owner.showToast(message)
+            })
         }
     }
 

--- a/SixthSense/Home/Sources/MyPageModifyInfo/Domain/MyPageModifyInfoUseCase.swift
+++ b/SixthSense/Home/Sources/MyPageModifyInfo/Domain/MyPageModifyInfoUseCase.swift
@@ -12,7 +12,7 @@ import RxSwift
 
 public protocol MyPageModifyInfoUseCase {
     func validateUserNickname(request: String) -> Observable<String>
-    func modifyUserInfo(userInfo: UserInfoRequest) -> Observable<String>
+    func modifyUserInfo(userInfo: UserInfoRequest) -> Observable<UserInfoPayload?>
 }
 
 final class MyPageModifyInfoUseCaseImpl: MyPageModifyInfoUseCase {
@@ -27,7 +27,10 @@ final class MyPageModifyInfoUseCaseImpl: MyPageModifyInfoUseCase {
         return userRepository.validateNickname(request: request).asObservable()
     }
 
-    func modifyUserInfo(userInfo request: UserInfoRequest) -> Observable<String> {
-        return userRepository.modifyUserInfo(request: request).asObservable()
+    func modifyUserInfo(userInfo request: UserInfoRequest) -> Observable<UserInfoPayload?> {
+        return userRepository.modifyUserInfo(request: request)
+            .compactMap({ UserInfoModel(JSONString: $0) })
+            .compactMap({ UserInfoPayload(model: $0) })
+            .asObservable()
     }
 }

--- a/SixthSense/Home/Sources/MyPageModifyInfo/RIB/MyPageModifyInfoBuilder.swift
+++ b/SixthSense/Home/Sources/MyPageModifyInfo/RIB/MyPageModifyInfoBuilder.swift
@@ -11,18 +11,23 @@ import Repository
 
 protocol MyPageModifyInfoDependency: Dependency {
     var userRepository: UserRepository { get }
+    var userInfoPayload: UserInfoPayload { get }
 }
 
 final class MyPageModifyInfoComponent: Component<MyPageModifyInfoDependency> {
     var useCase: MyPageModifyInfoUseCase { MyPageModifyInfoUseCaseImpl(userRepository: dependency.userRepository) }
+    var userInfoPayload: UserInfoPayload
+
+    override init(dependency: MyPageModifyInfoDependency) {
+        self.userInfoPayload = dependency.userInfoPayload
+        super.init(dependency: dependency)
+    }
 }
 
 // MARK: - Builder
 
 protocol MyPageModifyInfoBuildable: Buildable {
-    func build(withListener listener: MyPageModifyInfoListener,
-               type: ModifyType,
-               userInfoPayload: UserInfoPayload) -> MyPageModifyInfoRouting
+    func build(withListener listener: MyPageModifyInfoListener, type: ModifyType) -> MyPageModifyInfoRouting
 }
 
 final class MyPageModifyInfoBuilder: Builder<MyPageModifyInfoDependency>, MyPageModifyInfoBuildable {
@@ -31,12 +36,10 @@ final class MyPageModifyInfoBuilder: Builder<MyPageModifyInfoDependency>, MyPage
         super.init(dependency: dependency)
     }
 
-    func build(withListener listener: MyPageModifyInfoListener,
-               type: ModifyType,
-               userInfoPayload: UserInfoPayload) -> MyPageModifyInfoRouting {
+    func build(withListener listener: MyPageModifyInfoListener, type: ModifyType) -> MyPageModifyInfoRouting {
         let component = MyPageModifyInfoComponent(dependency: dependency)
         let viewController = MyPageModifyInfoViewController(type: type)
-        let interactor = MyPageModifyInfoInteractor(presenter: viewController, dependency: component, userInfoPayload: userInfoPayload)
+        let interactor = MyPageModifyInfoInteractor(presenter: viewController, component: component)
         interactor.listener = listener
         return MyPageModifyInfoRouter(interactor: interactor, viewController: viewController)
     }

--- a/SixthSense/Home/Sources/MyPageModifyInfo/RIB/MyPageModifyInfoInteractor.swift
+++ b/SixthSense/Home/Sources/MyPageModifyInfo/RIB/MyPageModifyInfoInteractor.swift
@@ -42,7 +42,7 @@ protocol MyPageModifyInfoPresenterAction: AnyObject {
 }
 
 protocol MyPageModifyInfoListener: AnyObject {
-    func popModifyInfoView(userInfo: UserInfoPayload)
+    func popModifyInfoView(userInfo: UserInfoPayload?)
 }
 
 final class MyPageModifyInfoInteractor: PresentableInteractor<MyPageModifyInfoPresentable>, MyPageModifyInfoInteractable {
@@ -94,7 +94,7 @@ final class MyPageModifyInfoInteractor: PresentableInteractor<MyPageModifyInfoPr
         action.didTapBackButton
             .withUnretained(self)
             .bind(onNext: { owner, _ in
-            owner.listener?.popModifyInfoView(userInfo: owner.component.userInfoPayload)
+            owner.listener?.popModifyInfoView(userInfo: nil)
         }).disposeOnDeactivate(interactor: self)
 
         action.didTapDoneButton

--- a/SixthSense/Home/Sources/MyPageModifyInfo/RIB/MyPageModifyInfoViewController.swift
+++ b/SixthSense/Home/Sources/MyPageModifyInfo/RIB/MyPageModifyInfoViewController.swift
@@ -15,6 +15,7 @@ import Account
 import RxAppState
 import DesignSystem
 import RxKeyboard
+import UICore
 
 final class MyPageModifyInfoViewController: UIViewController, MyPageModifyInfoPresentable, MyPageModifyInfoViewControllable {
 
@@ -147,6 +148,7 @@ extension MyPageModifyInfoViewController {
         handleBirthSubView(with: handler)
         handleVeganStageSubView(with: handler)
         handleDoneButton(with: handler)
+        handleErrorToast(with: handler)
     }
 
     private func handleNicknameSubView(with handler: MyPageModifyInfoPresenterHandler) {
@@ -242,6 +244,14 @@ extension MyPageModifyInfoViewController {
             .skip(1)
             .drive(onNext: { height in
             completion(height)
+        }).disposed(by: disposeBag)
+    }
+
+    private func handleErrorToast(with handler: MyPageModifyInfoPresenterHandler) {
+        handler.showErrorToast
+            .withUnretained(self)
+            .bind(onNext: { owner, message in
+            owner.showToast(message, toastStyle: .error)
         }).disposed(by: disposeBag)
     }
 }

--- a/SixthSense/Repository/Sources/User/UserRepositoryImpl.swift
+++ b/SixthSense/Repository/Sources/User/UserRepositoryImpl.swift
@@ -55,11 +55,7 @@ public final class UserRepositoryImpl: UserRepository {
     }
 
     public func modifyUserInfo(request: UserInfoRequest) -> Single<String> {
-        return network.request(UserAPI.modifyUserInfo(request))
-            .mapString()
-            .flatMap { data -> Single<String> in
-            return .just("")
-        }
+        return network.request(UserAPI.modifyUserInfo(request)).mapString()
     }
 
     public func challengeStats() -> Single<String> {


### PR DESCRIPTION
- Resolved #149 
---

### 설명
> 회원정보수정을 했을때 성공/실패 케이스에 따라서 토스트를 띄우고, 성공시 payload를 업데이트 했어요.


### 작업사항
- [x] : 마이페이지에서 사용되는 `UserInfoPayload`를 `MyPageRIB`에서 관리하도록 변경 
    - local var로 가지고 있는것보다 dependency로 가지고 있는게 더 좋을 것 같아요
- [x] : usecase에서 payload로 매핑
- [x] : repository에 `mapstring("")` 제거 
- [x] : 마이페이지 수정상세에서 에러토스트 적용
- [x] : 마이페이지 수정에서 성공토스트 적용


### 스크린샷

> 성공 토스트

https://user-images.githubusercontent.com/62925639/190693895-e4ac4e9d-1a34-4f89-8e0f-035c1b4ee435.MP4

> 에러 토스트

https://user-images.githubusercontent.com/62925639/190693956-a26a55b3-5625-40e1-b632-f36b701d7762.MP4

