### PR TITLE
[BUGFIX] 작은 화면 대응 - cell 크기를 조절했어요

### DIFF
--- a/SixthSense/Challenge/Sources/ChallengeRecommend/Presentation/Cell/RecommendItemCell.swift
+++ b/SixthSense/Challenge/Sources/ChallengeRecommend/Presentation/Cell/RecommendItemCell.swift
@@ -64,9 +64,9 @@ final class RecommendItemCell: UICollectionViewCell {
     private func configureLayout() {
 
         recommendImageView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(120)
             $0.left.right.equalToSuperview().inset(56)
-            $0.height.equalTo(250).multipliedBy(262 / 246)
+            $0.height.equalToSuperview().dividedBy(3)
         }
 
         defaultLabel.snp.makeConstraints {

--- a/SixthSense/Challenge/Sources/ChallengeRecommend/Presentation/RIB/ChallengeRecommendViewController.swift
+++ b/SixthSense/Challenge/Sources/ChallengeRecommend/Presentation/RIB/ChallengeRecommendViewController.swift
@@ -29,9 +29,9 @@ final class ChallengeRecommendViewController: UIViewController, ChallengeRecomme
 
         enum Inset {
             static let base = 20.0
-            static let collectionTop = 32.0
+            static let skipButtonTop = 60.0
             static let collectionBottom = -44.0
-            static let pageControlBottom = -70.0
+            static let pageControlBottom = -65.0
         }
     }
 
@@ -58,7 +58,7 @@ final class ChallengeRecommendViewController: UIViewController, ChallengeRecomme
     private var collectionLayout = UICollectionViewFlowLayout().then {
         $0.estimatedItemSize = .zero
         $0.itemSize = CGSize(width: UIScreen.main.bounds.width,
-                             height: UIScreen.main.bounds.height * 0.435)
+                             height: UIScreen.main.bounds.height)
         $0.scrollDirection = .horizontal
         $0.minimumInteritemSpacing = 0
         $0.minimumLineSpacing = 0
@@ -119,20 +119,18 @@ private extension ChallengeRecommendViewController {
     private func configureUI() {
         view.backgroundColor = .white
         recommendCollectionView.register(RecommendItemCell.self)
-        view.addSubviews(skipButton, recommendCollectionView, pageControl, doneButton)
+        view.addSubviews(recommendCollectionView, skipButton, pageControl, doneButton)
     }
 
     private func configureLayout() {
 
         skipButton.snp.makeConstraints {
             $0.right.equalToSuperview().inset(Constants.Inset.base)
-            $0.top.equalToSuperview().inset(view.safeAreaInsets.top + 11)
+            $0.top.equalToSuperview().inset(Constants.Inset.skipButtonTop)
         }
 
         recommendCollectionView.snp.makeConstraints {
-            $0.left.right.equalToSuperview()
-            $0.top.equalTo(skipButton.snp.bottom).offset(Constants.Inset.collectionTop)
-            $0.bottom.equalTo(pageControl.snp.top).offset(Constants.Inset.collectionBottom)
+            $0.edges.equalToSuperview()
         }
 
         pageControl.snp.makeConstraints {


### PR DESCRIPTION
### 설명
> iphone 6s, 8, mini, se와 같이 작은 화면에서 챌린지 추천 목록 이미지들이 깨지는 버그를 수정했어요.


### 작업사항
- [x] : 작은 화면 cell 크기 대응

